### PR TITLE
Add proofs for tensor-zero and parr-top equivalences

### DIFF
--- a/Cslib/Logic/LinearLogic/CLL/Basic.lean
+++ b/Cslib/Logic/LinearLogic/CLL/Basic.lean
@@ -189,6 +189,17 @@ theorem tensor_zero_eqv_zero (a : @Proposition Atom) :
     exact Proof.top
   · exact Proof.top
 
+/-- a ⅋ ⊤ ≡ ⊤ -/
+theorem parr_top_eqv_top (a : @Proposition Atom) :
+    parr a top ≡ top := by
+  constructor
+  · apply Proof.exchange (List.Perm.swap (parr a top).dual top [])
+    exact Proof.top
+  · apply Proof.exchange (List.Perm.swap top.dual (parr a top) [])
+    apply Proof.parr
+    apply Proof.exchange (List.Perm.swap a top [top.dual])
+    exact Proof.top
+
 end Proposition
 
 end LogicalEquiv

--- a/Cslib/Logic/LinearLogic/CLL/Basic.lean
+++ b/Cslib/Logic/LinearLogic/CLL/Basic.lean
@@ -180,6 +180,15 @@ theorem quest_zero_eqv_bot : (quest zero) ≡ @bot Atom := by
     apply Proof.weaken
     exact Proof.one
 
+/-- a ⊗ 0 ≡ 0 -/
+theorem tensor_zero_eqv_zero (a : @Proposition Atom) :
+    tensor a zero ≡ zero := by
+  constructor
+  · apply Proof.parr
+    apply Proof.exchange (List.Perm.swap a.dual (top) [zero])
+    exact Proof.top
+  · exact Proof.top
+
 end Proposition
 
 end LogicalEquiv

--- a/Cslib/Logic/LinearLogic/CLL/Basic.lean
+++ b/Cslib/Logic/LinearLogic/CLL/Basic.lean
@@ -56,6 +56,9 @@ instance : Top (@Proposition Atom) where
 instance : Bot (@Proposition Atom) where
   bot := Proposition.bot
 
+scoped infix:35 " ⊗ " => Proposition.tensor
+scoped infix:30 " ⅋ " => Proposition.parr
+
 /-- Positive propositions. -/
 def Proposition.Pos (a : @Proposition Atom) : Prop :=
   match a with
@@ -169,7 +172,7 @@ section LogicalEquiv
 /-- Two propositions are equivalent if one implies the other and vice versa. -/
 def Proposition.equiv (a b : @Proposition Atom) : Prop := ⊢[a.dual, b] ∧ ⊢[b.dual, a]
 
-scoped infix:90 " ≡ " => Proposition.equiv
+scoped infix:29 " ≡ " => Proposition.equiv
 
 namespace Proposition
 
@@ -197,7 +200,7 @@ theorem quest_zero_eqv_bot : (@quest Atom 0) ≡ ⊥ := by
 
 /-- a ⊗ 0 ≡ 0 -/
 theorem tensor_zero_eqv_zero (a : @Proposition Atom) :
-    tensor a 0 ≡ 0 := by
+    a ⊗ 0 ≡ 0 := by
   constructor
   · apply Proof.parr
     apply Proof.exchange (List.Perm.swap a.dual (top) [zero])
@@ -206,7 +209,7 @@ theorem tensor_zero_eqv_zero (a : @Proposition Atom) :
 
 /-- a ⅋ ⊤ ≡ ⊤ -/
 theorem parr_top_eqv_top (a : @Proposition Atom) :
-    parr a ⊤ ≡ ⊤ := by
+    a ⅋ ⊤ ≡ ⊤ := by
   constructor
   · apply Proof.exchange (List.Perm.swap (parr a top).dual top [])
     exact Proof.top

--- a/Cslib/Logic/LinearLogic/CLL/Basic.lean
+++ b/Cslib/Logic/LinearLogic/CLL/Basic.lean
@@ -197,7 +197,7 @@ theorem quest_zero_eqv_bot : (@quest Atom 0) ≡ ⊥ := by
 
 /-- a ⊗ 0 ≡ 0 -/
 theorem tensor_zero_eqv_zero (a : @Proposition Atom) :
-    tensor a zero ≡ zero := by
+    tensor a 0 ≡ 0 := by
   constructor
   · apply Proof.parr
     apply Proof.exchange (List.Perm.swap a.dual (top) [zero])
@@ -206,7 +206,7 @@ theorem tensor_zero_eqv_zero (a : @Proposition Atom) :
 
 /-- a ⅋ ⊤ ≡ ⊤ -/
 theorem parr_top_eqv_top (a : @Proposition Atom) :
-    parr a top ≡ top := by
+    parr a ⊤ ≡ ⊤ := by
   constructor
   · apply Proof.exchange (List.Perm.swap (parr a top).dual top [])
     exact Proof.top


### PR DESCRIPTION
 This PR adds two logical equivalences:
1. `a ⊗ 0 ≡ 0` (theorem `tensor_zero_eqv_zero`)
2. `a ⅋ ⊤ ≡ ⊤` (theorem `parr_top_eqv_top`)

It's a bit tedious to handle all these explicit `List.Perm` swaps in the equivalence proofs. Maybe we should create a separate file with a general API for moving stuff around in lists? That way we could have lemmas or even a tactic to make these permutation steps smoother. 

What do you think? 🙌
