### PR TITLE
use notation3 for Lts and ReductionSystem

### DIFF
--- a/Cslib/Semantics/Lts/Basic.lean
+++ b/Cslib/Semantics/Lts/Basic.lean
@@ -654,13 +654,13 @@ syntax "lts_transition_notation" ident (str)? : command
 macro_rules
   | `(lts_transition_notation $lts $sym) =>
     `(
-      notation3:39 t:39 "["μ"]⭢" $sym:str t':39 => (Lts.Tr.toRelation $lts μ) t t'
-      notation3:39 t:39 "["μs"]↠" $sym:str t':39 => (Lts.MTr.toRelation $lts μs) t t'
+      notation3 t:39 "["μ"]⭢" $sym:str t':39 => (Lts.Tr.toRelation $lts μ) t t'
+      notation3 t:39 "["μs"]↠" $sym:str t':39 => (Lts.MTr.toRelation $lts μs) t t'
      )
   | `(lts_transition_notation $lts) =>
     `(
-      notation3:39 t:39 "["μ"]⭢" t':39 => (Lts.Tr.toRelation $lts μ) t t'
-      notation3:39 t:39 "["μs"]↠" t':39 => (Lts.MTr.toRelation $lts μs) t t'
+      notation3 t:39 "["μ"]⭢" t':39 => (Lts.Tr.toRelation $lts μ) t t'
+      notation3 t:39 "["μs"]↠" t':39 => (Lts.MTr.toRelation $lts μs) t t'
      )
 
 /-- This attribute calls the `lts_transition_notation` command for the annotated declaration. -/

--- a/Cslib/Semantics/Lts/Basic.lean
+++ b/Cslib/Semantics/Lts/Basic.lean
@@ -10,6 +10,7 @@ import Mathlib.Data.Fintype.Basic
 import Mathlib.Logic.Function.Defs
 import Mathlib.Data.Set.Finite.Basic
 import Mathlib.Data.Stream.Defs
+import Mathlib.Util.Notation3
 
 /-!
 # Labelled Transition System (LTS)
@@ -649,21 +650,21 @@ elab "create_lts" lt:ident name:ident : command => do
   also used this as a constructor name, you will need quotes to access corresponding cases, e.g. «β»
   in the above example.
 -/
-syntax "lts_transition_notation" ident (Lean.Parser.Command.notationItem)? : command
+syntax "lts_transition_notation" ident (str)? : command
 macro_rules
   | `(lts_transition_notation $lts $sym) =>
     `(
-      notation:39 t "["μ"]⭢"$sym t' => (Lts.Tr.toRelation $lts μ) t t'
-      notation:39 t "["μs"]↠"$sym t' => (Lts.MTr.toRelation $lts μs) t t'
+      notation3:39 t:39 "["μ"]⭢" $sym:str t':39 => (Lts.Tr.toRelation $lts μ) t t'
+      notation3:39 t:39 "["μs"]↠" $sym:str t':39 => (Lts.MTr.toRelation $lts μs) t t'
      )
   | `(lts_transition_notation $lts) =>
     `(
-      notation:39 t "["μ"]⭢" t' => (Lts.Tr.toRelation $lts μ) t t'
-      notation:39 t "["μs"]↠" t' => (Lts.MTr.toRelation $lts μs) t t'
+      notation3:39 t:39 "["μ"]⭢" t':39 => (Lts.Tr.toRelation $lts μ) t t'
+      notation3:39 t:39 "["μs"]↠" t':39 => (Lts.MTr.toRelation $lts μs) t t'
      )
 
 /-- This attribute calls the `lts_transition_notation` command for the annotated declaration. -/
-syntax (name := lts_attr) "lts" ident (Lean.Parser.Command.notationItem)? : attr
+syntax (name := lts_attr) "lts" ident (ppSpace str)? : attr
 
 initialize Lean.registerBuiltinAttribute {
   name := `lts_attr
@@ -671,6 +672,9 @@ initialize Lean.registerBuiltinAttribute {
   add := fun decl stx _ => MetaM.run' do
     match stx with
     | `(attr | lts $lts $sym) =>
+        let mut sym := sym
+        unless sym.getString.endsWith " " do
+          sym := Syntax.mkStrLit (sym.getString ++ " ")
         let lts := lts.getId.updatePrefix decl.getPrefix |> Lean.mkIdent
         liftCommandElabM <| Command.elabCommand (← `(create_lts $(mkIdent decl) $lts))
         liftCommandElabM <| Command.elabCommand (← `(lts_transition_notation $lts $sym))

--- a/Cslib/Semantics/ReductionSystem/Basic.lean
+++ b/Cslib/Semantics/ReductionSystem/Basic.lean
@@ -5,6 +5,7 @@ Authors: Fabrizio Montesi, Thomas Waring
 -/
 
 import Mathlib.Logic.Relation
+import Mathlib.Util.Notation3
 
 /-!
 # Reduction System
@@ -98,17 +99,17 @@ elab "create_reduction_sys" rel:ident name:ident : command => do
   also used this as a constructor name, you will need quotes to access corresponding cases, e.g. «β»
   in the above example.
 -/
-syntax "reduction_notation" ident (Lean.Parser.Command.notationItem)? : command
+syntax "reduction_notation" ident (str)? : command
 macro_rules
   | `(reduction_notation $rs $sym) => 
     `(
-      notation:39 t " ⭢"$sym t' => (ReductionSystem.Red  $rs) t t'
-      notation:39 t " ↠"$sym t' => (ReductionSystem.MRed $rs) t t'
+      notation3:39 t:39 " ⭢" $sym:str t':39 => (ReductionSystem.Red  $rs) t t'
+      notation3:39 t:39 " ↠" $sym:str t':39 => (ReductionSystem.MRed $rs) t t'
      )
   | `(reduction_notation $rs) => 
     `(
-      notation:39 t " ⭢" t' => (ReductionSystem.Red  $rs) t t'
-      notation:39 t " ↠" t' => (ReductionSystem.MRed $rs) t t'
+      notation3:39 t:39 " ⭢" t':39 => (ReductionSystem.Red  $rs) t t'
+      notation3:39 t:39 " ↠" t':39 => (ReductionSystem.MRed $rs) t t'
      )
 
 
@@ -120,7 +121,7 @@ macro_rules
   def PredReduction (a b : ℕ) : Prop := a = b + 1
   ```
 -/
-syntax (name := reduction_sys) "reduction_sys" ident (Lean.Parser.Command.notationItem)? : attr
+syntax (name := reduction_sys) "reduction_sys" ident (ppSpace str)? : attr
 
 initialize Lean.registerBuiltinAttribute {
   name := `reduction_sys
@@ -128,6 +129,9 @@ initialize Lean.registerBuiltinAttribute {
   add := fun decl stx _ => MetaM.run' do
     match stx with
     | `(attr | reduction_sys $rs $sym) =>
+        let mut sym := sym
+        unless sym.getString.endsWith " " do
+          sym := Syntax.mkStrLit (sym.getString ++ " ")
         let rs := rs.getId.updatePrefix decl.getPrefix |> Lean.mkIdent
         liftCommandElabM <| Command.elabCommand (← `(create_reduction_sys $(mkIdent decl) $rs))
         liftCommandElabM <| Command.elabCommand (← `(reduction_notation $rs $sym))

--- a/Cslib/Semantics/ReductionSystem/Basic.lean
+++ b/Cslib/Semantics/ReductionSystem/Basic.lean
@@ -103,13 +103,13 @@ syntax "reduction_notation" ident (str)? : command
 macro_rules
   | `(reduction_notation $rs $sym) => 
     `(
-      notation3:39 t:39 " ⭢" $sym:str t':39 => (ReductionSystem.Red  $rs) t t'
-      notation3:39 t:39 " ↠" $sym:str t':39 => (ReductionSystem.MRed $rs) t t'
+      notation3 t:39 " ⭢" $sym:str t':39 => (ReductionSystem.Red  $rs) t t'
+      notation3 t:39 " ↠" $sym:str t':39 => (ReductionSystem.MRed $rs) t t'
      )
   | `(reduction_notation $rs) => 
     `(
-      notation3:39 t:39 " ⭢" t':39 => (ReductionSystem.Red  $rs) t t'
-      notation3:39 t:39 " ↠" t':39 => (ReductionSystem.MRed $rs) t t'
+      notation3 t:39 " ⭢" t':39 => (ReductionSystem.Red  $rs) t t'
+      notation3 t:39 " ↠" t':39 => (ReductionSystem.MRed $rs) t t'
      )
 
 

--- a/CslibTests/Lts.lean
+++ b/CslibTests/Lts.lean
@@ -115,3 +115,13 @@ end foo
 /-- info: foo.namespaced_lts : Lts ℕ ℕ -/
 #guard_msgs in
 #check foo.namespaced_lts
+
+-- check that delaborators work, including with variables
+
+/-- info: ∀ (a b : Term) (μ : Label), a[μ]⭢β b : Prop -/
+#guard_msgs in
+#check ∀ (a b : Term) (μ : Label), a [μ]⭢β b
+
+/-- info: ∀ (a b : Term) (μ : Label), a[[μ]]↠β b : Prop -/
+#guard_msgs in
+#check ∀ (a b : Term) (μ : Label), a [[μ]]↠β b

--- a/CslibTests/ReductionSystem.lean
+++ b/CslibTests/ReductionSystem.lean
@@ -50,3 +50,21 @@ end foo
 /-- info: foo.namespaced_rs : ReductionSystem ℕ -/
 #guard_msgs in
 #check foo.namespaced_rs
+
+-- check that delaborators work, including with variables
+
+/-- info: ∀ (a b : ℕ), a ⭢ₙ b : Prop -/
+#guard_msgs in
+#check ∀ (a b : ℕ), a ⭢ₙ b
+
+/-- info: ∀ (a b : ℕ), a ↠ₙ b : Prop -/
+#guard_msgs in
+#check ∀ (a b : ℕ), a ↠ₙ b
+
+/-- info: ∀ (a b : Term Var), a ⭢β b : Prop -/
+#guard_msgs in
+#check ∀ (a b : Term Var), a ⭢β b
+
+/-- info: ∀ (a b : Term Var), a ↠β b : Prop -/
+#guard_msgs in
+#check ∀ (a b : Term Var), a ↠β b


### PR DESCRIPTION
This is in reference to https://github.com/cs-lean/cslib/issues/23#issuecomment-3131138166. It turns out that Mathlib already supports deriving a delaborator for notations declared with `notation3`. This is even better than an unexpander, because it works with expressions rather than syntax and by default works with uses of `variable`. The end result is that any use of `{Lts,ReductionSystem}.{Red,MRed}` is printed as their corresponding arrow in the infoview. 

I also:
- cleaned up a few small details about whitespace in the notations.
- moved the precedence markers to the arguments so that you can for instance write `¬ a ↠β b` without parenthesis