### PR TITLE
All Lints Corrected!

### DIFF
--- a/Cslib/Computability/CombinatoryLogic/Basic.lean
+++ b/Cslib/Computability/CombinatoryLogic/Basic.lean
@@ -81,7 +81,7 @@ algorithm. We induct backwards on the list, corresponding to applying the transf
 inside out. Since we haven't defined reduction for polynomials, we substitute arbitrary terms
 for the inner variables.
 -/
-theorem Polynomial.elimVar_correct {n : Nat} (Γ : SKI.Polynomial (n+1)) {ys : List SKI}
+theorem Polynomial.elimVar_correct {n : Nat} (Γ : SKI.Polynomial (n + 1)) {ys : List SKI}
     (hys : ys.length = n) (z : SKI) :
     Γ.elimVar.eval ys hys ⬝ z ⇒* Γ.eval (ys ++ [z])
       (by rw [List.length_append, hys, List.length_singleton])
@@ -93,10 +93,10 @@ theorem Polynomial.elimVar_correct {n : Nat} (Γ : SKI.Polynomial (n+1)) {ys : L
   | _, SKI.Polynomial.app Γ Δ =>
     rw [SKI.Polynomial.elimVar, SKI.Polynomial.eval]
     trans Γ.elimVar.eval ys hys ⬝ z ⬝ (Δ.elimVar.eval ys hys ⬝ z)
-    . exact MRed.S _ _ _
-    . apply parallel_mRed
-      . exact elimVar_correct Γ hys z
-      . exact elimVar_correct Δ hys z
+    · exact MRed.S _ _ _
+    · apply parallel_mRed
+      · exact elimVar_correct Γ hys z
+      · exact elimVar_correct Δ hys z
   | n, SKI.Polynomial.var i =>
     rw [SKI.Polynomial.elimVar]
     split_ifs with hi
@@ -249,7 +249,7 @@ theorem ΘAux_def (x y : SKI) : ΘAux ⬝ x ⬝ y ⇒* y ⬝ (x ⬝ x ⬝ y) :=
   ΘAuxPoly.toSKI_correct [x, y] (by simp)
 
 
-/--Turing's fixed-point combinator: Θ := (λ x y. y (x x y)) (λ x y. y (x x y)) -/
+/-- Turing's fixed-point combinator: Θ := (λ x y. y (x x y)) (λ x y. y (x x y)) -/
 def Θ : SKI := ΘAux ⬝ ΘAux
 /-- A SKI term representing Θ -/
 theorem Θ_correct (f : SKI) : Θ ⬝ f ⇒* f ⬝ (Θ ⬝ f) := ΘAux_def ΘAux f
@@ -367,11 +367,11 @@ theorem unpaired_def (f p : SKI) : SKI.Unpaired ⬝ f ⬝ p ⇒* f ⬝ (Fst ⬝ 
 
 theorem unpaired_correct (f x y : SKI) : SKI.Unpaired ⬝ f ⬝ (MkPair ⬝ x ⬝ y) ⇒* f ⬝ x ⬝ y := by
   trans f ⬝ (Fst ⬝ (MkPair ⬝ x ⬝ y)) ⬝ (Snd ⬝ (MkPair ⬝ x ⬝ y))
-  . exact unpaired_def f _
-  . apply parallel_mRed
-    . apply MRed.tail
+  · exact unpaired_def f _
+  · apply parallel_mRed
+    · apply MRed.tail
       exact fst_correct _ _
-    . exact snd_correct _ _
+    · exact snd_correct _ _
 
 /-- Pair f g x := ⟨f x, g x⟩, cf `Primrec.Pair`. -/
 def PairPoly : SKI.Polynomial 3 := MkPair ⬝' (&0 ⬝' &2) ⬝' (&1 ⬝' &2)
@@ -379,3 +379,5 @@ def PairPoly : SKI.Polynomial 3 := MkPair ⬝' (&0 ⬝' &2) ⬝' (&1 ⬝' &2)
 protected def Pair : SKI := PairPoly.toSKI
 theorem pair_def (f g x : SKI) : SKI.Pair ⬝ f ⬝ g ⬝ x ⇒* MkPair ⬝ (f ⬝ x) ⬝ (g ⬝ x) :=
   PairPoly.toSKI_correct [f, g, x] (by simp)
+
+end SKI

--- a/Cslib/Computability/CombinatoryLogic/Confluence.lean
+++ b/Cslib/Computability/CombinatoryLogic/Confluence.lean
@@ -61,8 +61,8 @@ theorem mRed_of_parallelReduction {a a' : SKI} (h : a ⇒ₚ a') : a ⇒* a' := 
   case refl => exact Relation.ReflTransGen.refl
   case par a a' b b' ha hb =>
     apply parallel_mRed
-    exact mRed_of_parallelReduction ha
-    exact mRed_of_parallelReduction hb
+    · exact mRed_of_parallelReduction ha
+    · exact mRed_of_parallelReduction hb
   case red_I => exact Relation.ReflTransGen.single (red_I a')
   case red_K b => exact Relation.ReflTransGen.single (red_K a' b)
   case red_S a b c => exact Relation.ReflTransGen.single (red_S a b c)
@@ -75,12 +75,12 @@ theorem parallelReduction_of_red {a a' : SKI} (h : a ⇒ a') : a ⇒ₚ a' := by
   case red_I => apply ParallelReduction.red_I
   case red_head a a' b h =>
     apply ParallelReduction.par
-    exact parallelReduction_of_red h
-    exact ParallelReduction.refl b
+    · exact parallelReduction_of_red h
+    · exact ParallelReduction.refl b
   case red_tail a b b' h =>
     apply ParallelReduction.par
-    exact ParallelReduction.refl a
-    exact parallelReduction_of_red h
+    · exact ParallelReduction.refl a
+    · exact parallelReduction_of_red h
 
 /-- The inclusions of `mRed_of_parallelReduction` and
 `parallelReduction_of_red` imply that `⇒` and `⇒ₚ` have the same reflexive-transitive
@@ -135,7 +135,8 @@ lemma Sa_irreducible (a c : SKI) (h : S ⬝ a ⇒ₚ c) : ∃ a', a ⇒ₚ a' �
     rw [S_irreducible b h]
     exact ⟨h', rfl⟩
 
-lemma Sab_irreducible (a b c : SKI) (h : S ⬝ a ⬝ b ⇒ₚ c) : ∃ a' b', a ⇒ₚ a' ∧ b ⇒ₚ b' ∧ c = S ⬝ a' ⬝ b' := by
+lemma Sab_irreducible (a b c : SKI) (h : S ⬝ a ⬝ b ⇒ₚ c) :
+    ∃ a' b', a ⇒ₚ a' ∧ b ⇒ₚ b' ∧ c = S ⬝ a' ⬝ b' := by
   cases h
   case refl =>
     use a; use b
@@ -237,3 +238,5 @@ theorem MRed.diamond (a b c : SKI) (hab : a ⇒* b) (hac : a ⇒* c) : CommonRed
   apply commonReduct_equivalence.trans (y := a)
   · exact commonReduct_equivalence.symm (commonReduct_of_single hab)
   · exact commonReduct_of_single hac
+
+end SKI

--- a/Cslib/Computability/CombinatoryLogic/Defs.lean
+++ b/Cslib/Computability/CombinatoryLogic/Defs.lean
@@ -50,7 +50,7 @@ namespace SKI
 scoped infixl:100 " ⬝ " => app
 
 /-- Apply a term to a list of terms -/
-def applyList (f : SKI) (xs : List SKI) : SKI := List.foldl (. ⬝ .) f xs
+def applyList (f : SKI) (xs : List SKI) : SKI := List.foldl (· ⬝ ·) f xs
 
 lemma applyList_concat (f : SKI) (ys : List SKI) (z : SKI) :
     f.applyList (ys ++ [z]) = f.applyList ys ⬝ z := by
@@ -141,3 +141,5 @@ lemma commonReduct_of_single {a b : SKI} (h : a ⇒* b) : CommonReduct a b := by
 theorem symmetric_commonReduct : Symmetric CommonReduct := Relation.symmetric_join
 theorem reflexive_commonReduct : Reflexive CommonReduct :=
   Relation.reflexive_join MRed.reflexive
+
+end SKI

--- a/Cslib/Computability/CombinatoryLogic/Recursion.lean
+++ b/Cslib/Computability/CombinatoryLogic/Recursion.lean
@@ -21,7 +21,8 @@ correctness proofs `zero_correct` and `succ_correct`.
 - Predecessor : a term `Pred` so that (`pred_correct`)
 `IsChurch n a → IsChurch n.pred (Pred ⬝ a)`.
 - Primitive recursion : a term `Rec` so that (`rec_correct_succ`) `IsChurch (n+1) a` implies
-`Rec ⬝ x ⬝ g ⬝ a ⇒* g ⬝ a ⬝ (Rec ⬝ x ⬝ g ⬝ (Pred ⬝ a))` and (`rec_correct_zero`) `IsChurch 0 a` implies
+`Rec ⬝ x ⬝ g ⬝ a ⇒* g ⬝ a ⬝ (Rec ⬝ x ⬝ g ⬝ (Pred ⬝ a))` and (`rec_correct_zero`) `IsChurch 0 a`
+implies
 `Rec ⬝ x ⬝ g ⬝ a ⇒* x`.
 - Unbounded root finding (μ-recursion) : given a term  `f` representing a function `fℕ: Nat → Nat`,
 which takes on the value 0 a term `RFind` such that (`rFind_correct`) `RFind ⬝ f ⇒* a` such that
@@ -108,7 +109,7 @@ To define the predecessor, iterate the function `PredAux` ⟨i, j⟩ ↦ ⟨j, j
 the  first component.
 -/
 def PredAuxPoly : SKI.Polynomial 1 := MkPair ⬝' (Snd ⬝' &0) ⬝' (SKI.Succ ⬝' (Snd ⬝' &0))
-/-- A term representing PredAux-/
+/-- A term representing PredAux -/
 def PredAux : SKI := PredAuxPoly.toSKI
 theorem predAux_def (p : SKI) :  PredAux ⬝ p ⇒* MkPair ⬝ (Snd ⬝ p) ⬝ (SKI.Succ ⬝ (Snd ⬝ p)) :=
   PredAuxPoly.toSKI_correct [p] (by simp)
@@ -122,11 +123,12 @@ theorem isChurchPair_trans (ns : Nat × Nat) (a a' : SKI) (h : a ⇒* a') :
   simp_rw [IsChurchPair]
   intro ⟨ha₁,ha₂⟩
   constructor
-  . apply isChurch_trans (a' := Fst ⬝ a')
+  · apply isChurch_trans (a' := Fst ⬝ a')
     · apply MRed.tail; exact h
     · exact ha₁
-  . apply isChurch_trans (a' := Snd ⬝ a')
-    apply MRed.tail; exact h; exact ha₂
+  · apply isChurch_trans (a' := Snd ⬝ a')
+    · apply MRed.tail; exact h
+    · exact ha₂
 
 theorem predAux_correct (p : SKI) (ns : Nat × Nat) (h : IsChurchPair ns p) :
     IsChurchPair ⟨ns.2, ns.2+1⟩ (PredAux ⬝ p) := by
@@ -224,7 +226,7 @@ theorem rec_zero (x g a : SKI) (ha : IsChurch 0 a) : Rec ⬝ x ⬝ g ⬝ a ⇒* 
       apply cond_correct
       exact isZero_correct 0 a ha
 
-theorem rec_succ (n : Nat) (x g a : SKI) (ha : IsChurch (n+1) a) :
+theorem rec_succ (n : Nat) (x g a : SKI) (ha : IsChurch (n + 1) a) :
     Rec ⬝ x ⬝ g ⬝ a ⇒* g ⬝ a ⬝ (Rec ⬝ x ⬝ g ⬝ (Pred ⬝ a)) := by
   calc
   _ ⇒* SKI.Cond ⬝ x ⬝ (g ⬝ a ⬝ (Rec ⬝ x ⬝ g ⬝ (Pred ⬝ a))) ⬝ (IsZero ⬝ a) := rec_def _ _ _
@@ -254,7 +256,7 @@ theorem rfindAboveAux_base (R₀ f a : SKI) (hfa : IsChurch 0 (f ⬝ a)) :
   _ ⇒* if (Nat.beq 0 0) then a else (R₀ ⬝ (SKI.Succ ⬝ a) ⬝ f) := by
       apply cond_correct
       apply isZero_correct _ _ hfa
-theorem rfindAboveAux_step (R₀ f a : SKI) {m : Nat} (hfa : IsChurch (m+1) (f ⬝ a)) :
+theorem rfindAboveAux_step (R₀ f a : SKI) {m : Nat} (hfa : IsChurch (m + 1) (f ⬝ a)) :
     RFindAboveAux ⬝ R₀ ⬝ a ⬝ f ⇒* R₀ ⬝ (SKI.Succ ⬝ a) ⬝ f := calc
   _ ⇒* SKI.Cond ⬝ a ⬝ (R₀ ⬝ (SKI.Succ ⬝ a) ⬝ f) ⬝ (IsZero ⬝ (f ⬝ a)) := rfindAboveAux_def _ _ _
   _ ⇒* if (Nat.beq (m+1) 0) then a else (R₀ ⬝ (SKI.Succ ⬝ a) ⬝ f) := by
@@ -381,3 +383,5 @@ theorem le_correct (n m : Nat) (a b : SKI) (ha : IsChurch n a) (hb : IsChurch m 
   apply isBool_trans (a' := IsZero ⬝ (SKI.Sub ⬝ a ⬝ b)) (h := le_def _ _)
   apply isZero_correct
   apply sub_correct <;> assumption
+
+end SKI

--- a/Cslib/Computability/LambdaCalculus/LocallyNameless/Stlc/Basic.lean
+++ b/Cslib/Computability/LambdaCalculus/LocallyNameless/Stlc/Basic.lean
@@ -139,11 +139,10 @@ lemma subst_aux :
     intros x _
     rw [
       subst_def, 
-      subst_open_var _ _ _ _ _ der.lc,
+      subst_open_var _ _ _ _ (by aesop) der.lc,
       show ⟨x, σ⟩ :: (Δ ++ Γ) = (⟨x, σ⟩ :: Δ) ++ Γ by aesop
       ]
-    apply ih 
-    all_goals aesop  
+    apply ih <;> aesop
 
 /-- Substitution for a context weakened by a single type. -/
 lemma typing_subst_head : 
@@ -162,3 +161,5 @@ theorem preservation_open {xs : Finset Var} :
   have ⟨fresh, free⟩ := fresh_exists (xs ∪ m.fv)
   rw [subst_intro fresh n m (by aesop) der.lc]
   exact typing_subst_head (mem fresh (by aesop)) der
+
+end LambdaCalculus.LocallyNameless.Stlc.Typing

--- a/Cslib/Computability/LambdaCalculus/LocallyNameless/Stlc/Context.lean
+++ b/Cslib/Computability/LambdaCalculus/LocallyNameless/Stlc/Context.lean
@@ -55,3 +55,5 @@ theorem wf_strengthen : (Δ ++ ⟨x, σ⟩ :: Γ)✓ → (Δ ++ Γ)✓ := by
   intros ok
   have sl : List.Sublist (Δ ++ Γ) (Δ ++ ⟨x, σ⟩ :: Γ) := by simp
   exact List.NodupKeys.sublist sl ok
+
+end LambdaCalculus.LocallyNameless.Stlc.Context

--- a/Cslib/Computability/LambdaCalculus/LocallyNameless/Untyped/Basic.lean
+++ b/Cslib/Computability/LambdaCalculus/LocallyNameless/Untyped/Basic.lean
@@ -44,7 +44,7 @@ def openRec (i : ℕ) (sub : Term Var) : Term Var → Term Var
 | bvar i' => if i = i' then sub else bvar i'
 | fvar x  => fvar x
 | app l r => app (openRec i sub l) (openRec i sub r)
-| abs M   => abs $ openRec (i+1) sub M
+| abs M   => abs <| openRec (i+1) sub M
 
 scoped notation:68 e "⟦" i " ↝ " sub "⟧"=> Term.openRec i sub e
 
@@ -70,7 +70,7 @@ def closeRec (k : ℕ) (x : Var) : Term Var → Term Var
 | fvar x' => if x = x' then bvar k else fvar x'
 | bvar i  => bvar i
 | app l r => app (closeRec k x l) (closeRec k x r)
-| abs t   => abs $ closeRec (k+1) x t
+| abs t   => abs <| closeRec (k+1) x t
 
 scoped notation:68 e "⟦" k " ↜ " x "⟧"=> Term.closeRec k x e
 
@@ -103,7 +103,7 @@ def subst (m : Term Var) (x : Var) (sub : Term Var) : Term Var :=
   | bvar i  => bvar i
   | fvar x' => if x = x' then sub else fvar x'
   | app l r => app (l.subst x sub) (r.subst x sub)
-  | abs M   => abs $ M.subst x sub
+  | abs M   => abs <| M.subst x sub
 
 /-- `Term.subst` is a substitution for λ-terms. Gives access to the notation `m[x := n]`. -/
 instance instHasSubstitutionTerm : HasSubstitution (Term Var) Var where
@@ -146,3 +146,5 @@ inductive LC : Term Var → Prop
 
 inductive Value : Term Var → Prop
 | abs (e : Term Var) : e.abs.LC → e.abs.Value
+
+end LambdaCalculus.LocallyNameless.Term

--- a/Cslib/Computability/LambdaCalculus/LocallyNameless/Untyped/FullBeta.lean
+++ b/Cslib/Computability/LambdaCalculus/LocallyNameless/Untyped/FullBeta.lean
@@ -45,14 +45,14 @@ lemma step_lc_l (step : M ⭢βᶠ M') : LC M := by
   induction step <;> constructor
   all_goals assumption
 
-/-- Left congruence rule for application in multiple reduction.-/
+/-- Left congruence rule for application in multiple reduction. -/
 theorem redex_app_l_cong : (M ↠βᶠ M') → LC N → (app M N ↠βᶠ app M' N) := by
   intros redex lc_N 
   induction' redex
   case refl => rfl
   case tail ih r => exact Relation.ReflTransGen.tail r (appR lc_N ih)
 
-/-- Right congruence rule for application in multiple reduction.-/
+/-- Right congruence rule for application in multiple reduction. -/
 theorem redex_app_r_cong : (M ↠βᶠ M') → LC N → (app N M ↠βᶠ app N M') := by
   intros redex lc_N 
   induction' redex
@@ -68,7 +68,8 @@ lemma step_lc_r (step : M ⭢βᶠ M') : LC M' := by
   all_goals try constructor <;> assumption 
 
 /-- Substitution respects a single reduction step. -/
-lemma redex_subst_cong (s s' : Term Var) (x y : Var) : (s ⭢βᶠ s') → (s [ x := fvar y ]) ⭢βᶠ (s' [ x := fvar y ]) := by
+lemma redex_subst_cong (s s' : Term Var) (x y : Var) : 
+    s ⭢βᶠ s' → s [ x := fvar y ] ⭢βᶠ s' [ x := fvar y ] := by
   intros step
   induction step
   case appL ih => exact appL (subst_lc (by assumption) (by constructor)) ih 
@@ -89,7 +90,6 @@ lemma redex_subst_cong (s s' : Term Var) (x y : Var) : (s ⭢βᶠ s') → (s [ 
       subst_fresh x (fvar z) (fvar y), ←subst_fresh x (fvar z) (fvar y),
       ←subst_open x (fvar y) 0 (fvar z) m' (by constructor), subst_fresh x (fvar z) (fvar y)
     ]
-    apply ih
     all_goals aesop
 
 /-- Abstracting then closing preserves a single reduction. -/
@@ -99,9 +99,9 @@ lemma step_abs_close {x : Var} : (M ⭢βᶠ M') → (M⟦0 ↜ x⟧.abs ⭢β�
   intros y _
   simp only [open']
   repeat rw [open_close_to_subst]
-  exact redex_subst_cong M M' x y step
-  exact step_lc_r step
-  exact step_lc_l step
+  · exact redex_subst_cong M M' x y step
+  · exact step_lc_r step
+  · exact step_lc_l step
 
 /-- Abstracting then closing preserves multiple reductions. -/
 lemma redex_abs_close {x : Var} : (M ↠βᶠ M') → (M⟦0 ↜ x⟧.abs ↠βᶠ M'⟦0 ↜ x⟧.abs) :=  by
@@ -109,14 +109,17 @@ lemma redex_abs_close {x : Var} : (M ↠βᶠ M') → (M⟦0 ↜ x⟧.abs ↠β�
   induction step using Relation.ReflTransGen.trans_induction_on
   case ih₁ => rfl
   case ih₂ ih => exact Relation.ReflTransGen.single (step_abs_close ih)
-  case ih₃ l r => trans; exact l; exact r
+  case ih₃ l r => exact .trans l r
 
 /-- Multiple reduction of opening implies multiple reduction of abstraction. -/
-theorem redex_abs_cong (xs : Finset Var) : (∀ x ∉ xs, (M ^ fvar x) ↠βᶠ (M' ^ fvar x)) → M.abs ↠βᶠ M'.abs := by
+theorem redex_abs_cong (xs : Finset Var) : 
+    (∀ x ∉ xs, (M ^ fvar x) ↠βᶠ (M' ^ fvar x)) → M.abs ↠βᶠ M'.abs := by
   intros mem
   have ⟨fresh, union⟩ := fresh_exists (xs ∪ M.fv ∪ M'.fv)
   simp only [Finset.union_assoc, Finset.mem_union, not_or] at union
   obtain ⟨_, _, _⟩ := union
   rw [←open_close fresh M 0 ?_, ←open_close fresh M' 0 ?_]
-  refine redex_abs_close (mem fresh ?_)
+  · exact redex_abs_close (mem fresh (by assumption))
   all_goals assumption
+
+end LambdaCalculus.LocallyNameless.Term.FullBeta

--- a/Cslib/Data/FinFun.lean
+++ b/Cslib/Data/FinFun.lean
@@ -30,14 +30,17 @@ abbrev FinFun.apply (f : α ⇀ β) (x : α) : β := f.f x
 
 /- Conversion from FinFun to a function. -/
 @[coe] def FinFun.toFun [DecidableEq α] [Zero β] (f : α ⇀ β) : (α → β) :=
-  λ x => if x ∈ f.dom then f.f x else Zero.zero
+  fun x => if x ∈ f.dom then f.f x else Zero.zero
 
 instance [DecidableEq α] [Zero β] : Coe (α ⇀ β) (α → β) where
   coe := FinFun.toFun
 
-theorem FinFun.toFun_char [DecidableEq α] [Zero β] {f g : α ⇀ β} (h : (f : α → β) = (g : α → β)) : ∀ x, (x ∈ (f.dom ∩ g.dom) → f.apply x = g.apply x) ∧ (x ∈ (f.dom \ g.dom) → f.apply x = Zero.zero) ∧ (x ∈ (g.dom \ f.dom) → g.apply x = Zero.zero) := by
+theorem FinFun.toFun_char [DecidableEq α] [Zero β]
+    {f g : α ⇀ β} (h : (f : α → β) = (g : α → β)) (x) : 
+    (x ∈ (f.dom ∩ g.dom) →
+    f.apply x = g.apply x) ∧ (x ∈ (f.dom \ g.dom) →
+    f.apply x = Zero.zero) ∧ (x ∈ (g.dom \ f.dom) → g.apply x = Zero.zero) := by
   rename_i hdec hzero
-  intro x
   have happlyx : f.toFun x = g.toFun x := by simp [h]
   constructorm* _ ∧ _
   case left =>
@@ -57,13 +60,14 @@ theorem FinFun.toFun_char [DecidableEq α] [Zero β] {f g : α ⇀ β} (h : (f :
     simp [toFun, hx] at happlyx
     simp only [happlyx]
 
-theorem FinFun.toFun_dom [DecidableEq α] [Zero β] {f : α ⇀ β} (h : ∀ x, x ∉ f.dom → f.apply x = Zero.zero) : (f : α → β) = f.f := by
+theorem FinFun.toFun_dom [DecidableEq α] [Zero β] {f : α ⇀ β}
+    (h : ∀ x, x ∉ f.dom → f.apply x = Zero.zero) : (f : α → β) = f.f := by
   rename_i hdec hzero
   funext x
   by_cases hx : x ∈ f.dom
-  . simp only [FinFun.toFun]
+  · simp only [FinFun.toFun]
     simp [hx]
-  . simp only [FinFun.toFun]
+  · simp only [FinFun.toFun]
     simp [hx]
     specialize h x
     simp only [h hx]
@@ -75,10 +79,11 @@ theorem FinFun.toFun_dom [DecidableEq α] [Zero β] {f : α ⇀ β} (h : ∀ x, 
 --   dom := dom
 -- }
 
-def FinFun.mapBin [DecidableEq α] (f g : α ⇀ β) (op : Option β → Option β → Option β) : Option (α ⇀ β) :=
+def FinFun.mapBin [DecidableEq α] (f g : α ⇀ β) (op : Option β → Option β → Option β) : 
+    Option (α ⇀ β) :=
   if f.dom = g.dom ∧ ∀ x ∈ f.dom, (op (some (f.f x)) (some (g.f x))).isSome then
     some {
-      f := λ x =>
+      f := fun x =>
         match op (some (f.f x)) (some (g.f x)) with
           | some y => y
           | none => f.f x
@@ -87,20 +92,22 @@ def FinFun.mapBin [DecidableEq α] (f g : α ⇀ β) (op : Option β → Option 
   else
     none
 
-theorem FinFun.mapBin_dom [DecidableEq α] (f g : α ⇀ β) (op : Option β → Option β → Option β) (h : FinFun.mapBin f g op = some fg) :
-  fg.dom = f.dom ∧ fg.dom = g.dom := by
+theorem FinFun.mapBin_dom [DecidableEq α] (f g : α ⇀ β)
+    (op : Option β → Option β → Option β) (h : FinFun.mapBin f g op = some fg) :
+    fg.dom = f.dom ∧ fg.dom = g.dom := by
   rename_i hdec
   simp [mapBin] at h
   constructor
-  . simp only [← h]
-  . simp only [← h]
+  · simp only [← h]
+  · simp only [← h]
 
-theorem FinFun.mapBin_char₁ [DecidableEq α] (f g : α ⇀ β) (op : Option β → Option β → Option β) (h : FinFun.mapBin f g op = some fg) :
-  ∀ x ∈ fg.dom, fg.apply x = y ↔ (op (some (f.f x)) (some (g.f x))) = some y := by
+theorem FinFun.mapBin_char₁ [DecidableEq α] (f g : α ⇀ β)
+    (op : Option β → Option β → Option β) (h : FinFun.mapBin f g op = some fg) :
+    ∀ x ∈ fg.dom, fg.apply x = y ↔ (op (some (f.f x)) (some (g.f x))) = some y := by
   rename_i hdec
   intro x hxdom
   constructor
-  . intro happ
+  · intro happ
     simp only [FinFun.apply] at happ
     simp [mapBin] at h
     rcases h with ⟨⟨ h_fg_dom_eq, hxsome ⟩, ⟨fgf, what⟩⟩
@@ -112,13 +119,16 @@ theorem FinFun.mapBin_char₁ [DecidableEq α] (f g : α ⇀ β) (op : Option β
       simp only [happ]
     | none =>
       simp [hsome?] at hxsome
-  . intro hop
+  · intro hop
     simp [mapBin] at h
     rcases h with ⟨⟨ h_fg_dom_eq, hxsome ⟩, ⟨fgf, what⟩⟩
     simp
     simp [hop]
 
-theorem FinFun.mapBin_char₂ [DecidableEq α] (f g : α ⇀ β) (op : Option β → Option β → Option β) (hdom : f.dom = g.dom) (hop : ∀ x ∈ f.dom, (op (some (f.f x)) (some (g.f x))).isSome) : (FinFun.mapBin f g op).isSome := by
+theorem FinFun.mapBin_char₂ [DecidableEq α] (f g : α ⇀ β)
+    (op : Option β → Option β → Option β) (hdom : f.dom = g.dom)
+    (hop : ∀ x ∈ f.dom, (op (some (f.f x)) (some (g.f x))).isSome)
+    : (FinFun.mapBin f g op).isSome := by
   rename_i hdec
   simp [mapBin]
   simp [hdom]
@@ -131,24 +141,25 @@ theorem FinFun.mapBin_char₂ [DecidableEq α] (f g : α ⇀ β) (op : Option β
 -- Fun to FinFun
 def Function.toFinFun [DecidableEq α] (f : α → β) (dom : Finset α) : α ⇀ β := FinFun.mk f dom
 
-lemma Function.toFinFun_eq [DecidableEq α] [Zero β] (f : α → β) (dom : Finset α) (h : ∀ x, x ∉ dom → f x = 0) :
-  f = (Function.toFinFun f dom) := by
+lemma Function.toFinFun_eq [DecidableEq α] [Zero β] (f : α → β) (dom : Finset α)
+    (h : ∀ x, x ∉ dom → f x = 0) : f = (Function.toFinFun f dom) := by
   funext p
   by_cases hp : p ∈ dom
-  . simp [Function.toFinFun, FinFun.toFun]
+  · simp [Function.toFinFun, FinFun.toFun]
     simp [hp]
-  . simp [Function.toFinFun, FinFun.toFun]
+  · simp [Function.toFinFun, FinFun.toFun]
     simp [hp]
     specialize h p hp
     exact h
 
 @[coe] def FinFun.toDomFun (f : α ⇀ β) : {x // x ∈ f.dom} → β :=
-  λ x => f.f x
+  fun x => f.f x
 
 theorem FinFun.toDomFun_char (f : α ⇀ β) (h : x ∈ f.dom) : f.toDomFun ⟨ x, h ⟩ = f.f x := by
   simp [FinFun.toDomFun]
 
-theorem FinFun.congrFinFun [DecidableEq α] [Zero β] {f g : α ⇀ β} (h : f = g) (a : α) : f.apply a = g.apply a := by
+theorem FinFun.congrFinFun [DecidableEq α] [Zero β] {f g : α ⇀ β} (h : f = g) (a : α) : 
+    f.apply a = g.apply a := by
   simp [FinFun.apply]
   cases f
   rename_i ff fdom
@@ -158,7 +169,8 @@ theorem FinFun.congrFinFun [DecidableEq α] [Zero β] {f g : α ⇀ β} (h : f =
   obtain ⟨ h1, h2⟩ := h
   exact congrFun h1 a
 
-theorem FinFun.eq_char₁ [DecidableEq α] [Zero β] {f g : α ⇀ β} (h : f = g) : f.f = g.f ∧ f.dom = g.dom := by
+theorem FinFun.eq_char₁ [DecidableEq α] [Zero β] {f g : α ⇀ β} (h : f = g) : 
+    f.f = g.f ∧ f.dom = g.dom := by
   cases f
   rename_i ff fdom
   cases g
@@ -166,7 +178,8 @@ theorem FinFun.eq_char₁ [DecidableEq α] [Zero β] {f g : α ⇀ β} (h : f = 
   simp at h
   assumption
 
-theorem FinFun.eq_char₂ [DecidableEq α] [Zero β] {f g : α ⇀ β} (heq : f.f = g.f ∧ f.dom = g.dom) : f = g := by
+theorem FinFun.eq_char₂ [DecidableEq α] [Zero β] {f g : α ⇀ β} (heq : f.f = g.f ∧ f.dom = g.dom) : 
+    f = g := by
   cases f
   rename_i ff fdom
   cases g
@@ -175,7 +188,8 @@ theorem FinFun.eq_char₂ [DecidableEq α] [Zero β] {f g : α ⇀ β} (heq : f.
   simp
   assumption
 
-theorem FinFun.eq_char [DecidableEq α] [Zero β] {f g : α ⇀ β} : f = g ↔ f.f = g.f ∧ f.dom = g.dom := by
+theorem FinFun.eq_char [DecidableEq α] [Zero β] {f g : α ⇀ β} : 
+    f = g ↔ f.f = g.f ∧ f.dom = g.dom := by
   apply Iff.intro
-  . apply FinFun.eq_char₁
-  . apply FinFun.eq_char₂
+  · apply FinFun.eq_char₁
+  · apply FinFun.eq_char₂

--- a/Cslib/Logic/LinearLogic/CLL/Basic.lean
+++ b/Cslib/Logic/LinearLogic/CLL/Basic.lean
@@ -83,11 +83,15 @@ def Proposition.Neg (a : @Proposition Atom) : Prop :=
 
 /-- Whether a `Proposition` is positive is decidable. -/
 instance Proposition.pos_decidable (a : @Proposition Atom) : Decidable a.Pos := by
-  cases a <;> simp [Proposition.Pos] <;> first | apply Decidable.isTrue; simp | apply Decidable.isFalse; simp
+  cases a <;> 
+  simp only [Proposition.Pos] <;> 
+  first | apply Decidable.isTrue; trivial | apply Decidable.isFalse; trivial
 
 /-- Whether a `Proposition` is negative is decidable. -/
 instance Proposition.neg_decidable (a : @Proposition Atom) : Decidable a.Neg := by
-  cases a <;> simp [Proposition.Neg] <;> first | apply Decidable.isTrue; simp | apply Decidable.isFalse; simp
+  cases a <;> 
+  simp only [Proposition.Neg] <;> 
+  first | apply Decidable.isTrue; trivial | apply Decidable.isFalse; trivial
 
 /-- Propositional duality. -/
 def Proposition.dual (a : @Proposition Atom) : @Proposition Atom :=

--- a/Cslib/Semantics/Lts/Bisimulation.lean
+++ b/Cslib/Semantics/Lts/Bisimulation.lean
@@ -1064,16 +1064,21 @@ theorem WeakBisimulation.iff_swBisimulation
           apply Lts.STr.comp lts hstr1b hstr1b' hstr1'
         · exact hrb2
 
-theorem WeakBisimulation.toSwBisimulation [HasTau Label] {lts : Lts State Label} {r : State → State → Prop} (h : WeakBisimulation lts r) : SWBisimulation lts r := (WeakBisimulation.iff_swBisimulation lts r).1 h
+theorem WeakBisimulation.toSwBisimulation
+  [HasTau Label] {lts : Lts State Label} {r : State → State → Prop} (h : WeakBisimulation lts r) : 
+    SWBisimulation lts r := (WeakBisimulation.iff_swBisimulation lts r).1 h
 
-theorem SWBisimulation.toWeakBisimulation [HasTau Label] {lts : Lts State Label} {r : State → State → Prop} (h : SWBisimulation lts r) : WeakBisimulation lts r := (WeakBisimulation.iff_swBisimulation lts r).2 h
+theorem SWBisimulation.toWeakBisimulation
+  [HasTau Label] {lts : Lts State Label} {r : State → State → Prop} (h : SWBisimulation lts r) : 
+    WeakBisimulation lts r := (WeakBisimulation.iff_swBisimulation lts r).2 h
 
 /-- If two states are related by an `SWBisimulation`, then they are weakly bisimilar. -/
 theorem WeakBisimilarity.by_swBisimulation [HasTau Label]
   (lts : Lts State Label) (r : State → State → Prop)
   (hb : SWBisimulation lts r) (hr : r s1 s2) : s1 ≈[lts] s2 := by
   exists r
-  constructor; exact hr
+  constructor
+  · exact hr
   apply (WeakBisimulation.iff_swBisimulation lts r).2 hb
 
 /-- Weak bisimilarity and sw-bisimilarity coincide for all Ltss. -/
@@ -1086,20 +1091,23 @@ theorem WeakBisimilarity.weakBisim_eq_swBisim [HasTau Label] (lts : Lts State La
     intro h
     obtain ⟨r, hr, hrh⟩ := h
     exists r
-    constructor; exact hr
+    constructor
+    · exact hr
     apply (WeakBisimulation.iff_swBisimulation lts r).1 hrh
   case mpr =>
     intro h
     obtain ⟨r, hr, hrh⟩ := h
     exists r
-    constructor; exact hr
+    constructor
+    · exact hr
     apply (WeakBisimulation.iff_swBisimulation lts r).2 hrh
 
 /-- sw-bisimilarity is reflexive. -/
 theorem SWBisimilarity.refl [HasTau Label] (lts : Lts State Label) (s : State) : s ≈sw[lts] s := by
   simp [SWBisimilarity]
   exists Eq
-  constructor; rfl
+  constructor
+  · rfl
   simp only [SWBisimulation]
   intro s1 s2 hr μ
   cases hr
@@ -1153,7 +1161,8 @@ theorem WeakBisimulation.inv [HasTau Label] (lts : Lts State Label)
   exact h'
 
 /-- sw-bisimilarity is symmetric. -/
-theorem SWBisimilarity.symm [HasTau Label] (lts : Lts State Label) (h : s1 ≈sw[lts] s2) : s2 ≈sw[lts] s1 := by
+theorem SWBisimilarity.symm [HasTau Label] (lts : Lts State Label) (h : s1 ≈sw[lts] s2) : 
+    s2 ≈sw[lts] s1 := by
   obtain ⟨r, hr, hrh⟩ := h
   exists (flip r)
   constructor
@@ -1164,7 +1173,8 @@ theorem SWBisimilarity.symm [HasTau Label] (lts : Lts State Label) (h : s1 ≈sw
     apply SWBisimulation.inv lts r hrh
 
 /-- Weak bisimilarity is symmetric. -/
-theorem WeakBisimilarity.symm [HasTau Label] (lts : Lts State Label) (h : s1 ≈[lts] s2) : s2 ≈[lts] s1 := by
+theorem WeakBisimilarity.symm [HasTau Label] (lts : Lts State Label) (h : s1 ≈[lts] s2) : 
+    s2 ≈[lts] s1 := by
   rw [WeakBisimilarity.weakBisim_eq_swBisim]
   rw [WeakBisimilarity.weakBisim_eq_swBisim] at h
   apply SWBisimilarity.symm lts h
@@ -1217,9 +1227,8 @@ theorem SWBisimulation.comp
   apply WeakBisimulation.comp lts r1 r2 h1 h2
 
 /-- Weak bisimilarity is transitive. -/
-theorem WeakBisimilarity.trans
-  [HasTau Label] {s1 s2 s3 : State} (lts : Lts State Label) (h1 : s1 ≈[lts] s2) (h2 : s2 ≈[lts] s3) :
-  s1 ≈[lts] s3 := by
+theorem WeakBisimilarity.trans [HasTau Label] {s1 s2 s3 : State}
+    (lts : Lts State Label) (h1 : s1 ≈[lts] s2) (h2 : s2 ≈[lts] s3) : s1 ≈[lts] s3 := by
   obtain ⟨r1, hr1, hr1b⟩ := h1
   obtain ⟨r2, hr2, hr2b⟩ := h2
   exists Relation.Comp r1 r2
@@ -1230,9 +1239,8 @@ theorem WeakBisimilarity.trans
     apply WeakBisimulation.comp lts r1 r2 hr1b hr2b
 
 /-- sw-bisimilarity is transitive. -/
-theorem SWBisimilarity.trans
-  [HasTau Label] {s1 s2 s3 : State} (lts : Lts State Label) (h1 : s1 ≈sw[lts] s2) (h2 : s2 ≈sw[lts] s3) :
-  s1 ≈sw[lts] s3 := by
+theorem SWBisimilarity.trans [HasTau Label] {s1 s2 s3 : State}
+    (lts : Lts State Label) (h1 : s1 ≈sw[lts] s2) (h2 : s2 ≈sw[lts] s3) : s1 ≈sw[lts] s3 := by
   rw [← (WeakBisimilarity.weakBisim_eq_swBisim lts)] at *
   apply WeakBisimilarity.trans lts h1 h2
 

--- a/Cslib/Semantics/Lts/Bisimulation.lean
+++ b/Cslib/Semantics/Lts/Bisimulation.lean
@@ -1065,11 +1065,11 @@ theorem WeakBisimulation.iff_swBisimulation
         · exact hrb2
 
 theorem WeakBisimulation.toSwBisimulation
-  [HasTau Label] {lts : Lts State Label} {r : State → State → Prop} (h : WeakBisimulation lts r) : 
+  [HasTau Label] {lts : Lts State Label} {r : State → State → Prop} (h : WeakBisimulation lts r) :
     SWBisimulation lts r := (WeakBisimulation.iff_swBisimulation lts r).1 h
 
 theorem SWBisimulation.toWeakBisimulation
-  [HasTau Label] {lts : Lts State Label} {r : State → State → Prop} (h : SWBisimulation lts r) : 
+  [HasTau Label] {lts : Lts State Label} {r : State → State → Prop} (h : SWBisimulation lts r) :
     WeakBisimulation lts r := (WeakBisimulation.iff_swBisimulation lts r).2 h
 
 /-- If two states are related by an `SWBisimulation`, then they are weakly bisimilar. -/
@@ -1161,7 +1161,7 @@ theorem WeakBisimulation.inv [HasTau Label] (lts : Lts State Label)
   exact h'
 
 /-- sw-bisimilarity is symmetric. -/
-theorem SWBisimilarity.symm [HasTau Label] (lts : Lts State Label) (h : s1 ≈sw[lts] s2) : 
+theorem SWBisimilarity.symm [HasTau Label] (lts : Lts State Label) (h : s1 ≈sw[lts] s2) :
     s2 ≈sw[lts] s1 := by
   obtain ⟨r, hr, hrh⟩ := h
   exists (flip r)
@@ -1173,7 +1173,7 @@ theorem SWBisimilarity.symm [HasTau Label] (lts : Lts State Label) (h : s1 ≈sw
     apply SWBisimulation.inv lts r hrh
 
 /-- Weak bisimilarity is symmetric. -/
-theorem WeakBisimilarity.symm [HasTau Label] (lts : Lts State Label) (h : s1 ≈[lts] s2) : 
+theorem WeakBisimilarity.symm [HasTau Label] (lts : Lts State Label) (h : s1 ≈[lts] s2) :
     s2 ≈[lts] s1 := by
   rw [WeakBisimilarity.weakBisim_eq_swBisim]
   rw [WeakBisimilarity.weakBisim_eq_swBisim] at h

--- a/CslibTests/Lts.lean
+++ b/CslibTests/Lts.lean
@@ -32,13 +32,13 @@ inductive NatBisim : ℕ → ℕ → Prop where
 example : 1 ~[natLts] 2 := by
   exists NatBisim
   constructor
-  . constructor
-  . simp [Bisimulation]
+  · constructor
+  · simp [Bisimulation]
     intro s1 s2 hr μ
     constructor
-    . intro s1' htr
+    · intro s1' htr
       cases htr <;> (cases hr <;> repeat constructor)
-    . intro s2' htr
+    · intro s2' htr
       cases htr <;> (cases hr <;> repeat constructor)
 
 inductive TLabel : Type where
@@ -55,7 +55,8 @@ def natDivLts : Lts ℕ TLabel := ⟨NatDivergentTr⟩
 
 def natInfiniteExecution : Stream' ℕ := fun n => n
 
-theorem natInfiniteExecution.infiniteExecution : natDivLts.DivergentExecution natInfiniteExecution := by
+theorem natInfiniteExecution.infiniteExecution : 
+    natDivLts.DivergentExecution natInfiniteExecution := by
   simp [Lts.DivergentExecution]
   intro n
   constructor
@@ -89,7 +90,7 @@ example : natDivLts.Divergent n := by
 -- check that notation works
 variable {Term : Type} {Label : Type}
 @[lts lts "β", simp]
-def labelled_transition : Term → Label → Term → Prop := λ _ _ _ ↦ True
+def labelled_transition : Term → Label → Term → Prop := fun _ _ _ ↦ True
 
 example (a b : Term) (μ : Label) : a [μ]⭢β b := by
   change labelled_transition a μ b

--- a/CslibTests/ReductionSystem.lean
+++ b/CslibTests/ReductionSystem.lean
@@ -24,7 +24,7 @@ inductive Term (Var : Type)
 variable {Var : Type}
 
 @[reduction_sys rs' "β", simp]
-def term_rel : Term Var → Term Var → Prop := λ _ _ ↦ True
+def term_rel : Term Var → Term Var → Prop := fun _ _ ↦ True
 
 example (a b : Term Var) : a ⭢β b := by
   change (@term_rel Var) a b


### PR DESCRIPTION
This PR fixes all lints. The most common things I think were `.` versus `·`, line length, and tactics not focused on the current goal.

I would like to fix the workflow to report these, and asked a related [question on Zulip](https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/weak.2Elinter.2EmathlibStandardSet.20and.20lint-style-action). It would be nice to have this done before merging, but let's also try to avoid letting merge conflicts accumulate since this touches so many files. 