### PR TITLE
Migrate LambdaCalculus.LocallyNameless to `grind`

### DIFF
--- a/Cslib/Computability/LambdaCalculus/LocallyNameless/Context.lean
+++ b/Cslib/Computability/LambdaCalculus/LocallyNameless/Context.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Henson
 -/
 
-import Cslib.Computability.LambdaCalculus.LocallyNameless.Untyped.AesopRuleset
 import Cslib.Syntax.HasWellFormed
 import Mathlib.Data.Finset.Defs
 import Mathlib.Data.Finset.Dedup
@@ -20,19 +19,21 @@ universe u v
 
 variable {Var : Type u} {Ty : Type v} [DecidableEq Var]
 
-namespace LambdaCalculus.LocallyNameless.Stlc
+namespace LambdaCalculus.LocallyNameless
 
 /-- A typing context is a list of free variables and corresponding types. -/
 abbrev Context (Var : Type u) (Ty : Type v) := List ((_ : Var) × Ty)
 
 namespace Context
 
+open List
+
 /-- The domain of a context is the finite set of free variables it uses. -/
-@[simp]
-def dom : Context Var Ty → Finset Var := List.toFinset ∘ List.keys
+@[simp, grind =]
+def dom : Context Var Ty → Finset Var := toFinset ∘ keys
 
 /-- A well-formed context. -/
-abbrev Ok : Context Var Ty → Prop := List.NodupKeys
+abbrev Ok : Context Var Ty → Prop := NodupKeys
 
 instance : HasWellFormed (Context Var Ty) :=
   ⟨Ok⟩
@@ -40,20 +41,19 @@ instance : HasWellFormed (Context Var Ty) :=
 variable {Γ Δ : Context Var Ty}
 
 /-- Context membership is preserved on permuting a context. -/
-theorem dom_perm_mem_iff (h : Γ.Perm Δ) {x : Var} : 
-    x ∈ Γ.dom ↔ x ∈ Δ.dom := by
-  induction h <;> aesop
+theorem dom_perm_mem_iff (h : Γ.Perm Δ) {x : Var} : x ∈ Γ.dom ↔ x ∈ Δ.dom := by
+  induction h <;> simp_all only [dom, Function.comp_apply, mem_toFinset, keys_cons, mem_cons] 
+  grind
 
 omit [DecidableEq Var] in
 /-- Context well-formedness is preserved on permuting a context. -/
-@[aesop safe forward (rule_sets := [LambdaCalculus.LocallyNameless.ruleSet])]
+@[scoped grind →]
 theorem wf_perm (h : Γ.Perm Δ) : Γ✓ → Δ✓ := (List.perm_nodupKeys h).mp
 
 omit [DecidableEq Var] in
-@[aesop safe forward (rule_sets := [LambdaCalculus.LocallyNameless.ruleSet])]
-theorem wf_strengthen : (Δ ++ ⟨x, σ⟩ :: Γ)✓ → (Δ ++ Γ)✓ := by
-  intros ok
-  have sl : List.Sublist (Δ ++ Γ) (Δ ++ ⟨x, σ⟩ :: Γ) := by simp
-  exact List.NodupKeys.sublist sl ok
+/-- Context well-formedness is preserved on removing an element. -/
+@[scoped grind →]
+theorem wf_strengthen (ok : (Δ ++ ⟨x, σ⟩ :: Γ)✓) : (Δ ++ Γ)✓ := by
+  exact List.NodupKeys.sublist (by simp) ok
 
-end LambdaCalculus.LocallyNameless.Stlc.Context
+end LambdaCalculus.LocallyNameless.Context

--- a/Cslib/Computability/LambdaCalculus/LocallyNameless/Stlc/Basic.lean
+++ b/Cslib/Computability/LambdaCalculus/LocallyNameless/Stlc/Basic.lean
@@ -123,13 +123,8 @@ lemma subst_aux (h : Δ ++ ⟨x, σ⟩ :: Γ ⊢ t ∶ τ) (der : Γ ⊢ s ∶ �
       exact Context.wf_perm (id (List.Perm.symm perm)) ok_weak
   case abs σ Γ' t T2 xs ih' ih =>
     apply Typing.abs (xs ∪ {x} ∪ (Δ ++ Γ).dom)
-    intros x _
-    rw [
-      subst_def, 
-      ←subst_open_var _ _ _ _ (by grind) der.lc,
-      show ⟨x, σ⟩ :: (Δ ++ Γ) = (⟨x, σ⟩ :: Δ) ++ Γ by grind
-      ]
-    apply ih <;> grind
+    intros
+    rw [subst_def, ←subst_open_var _ _ _ _ ?_ der.lc] <;> grind
 
 /-- Substitution for a context weakened by a single type. -/
 lemma typing_subst_head (weak : ⟨x, σ⟩ :: Γ ⊢ t ∶ τ) (der : Γ ⊢ s ∶ σ) :

--- a/Cslib/Computability/LambdaCalculus/LocallyNameless/Stlc/Basic.lean
+++ b/Cslib/Computability/LambdaCalculus/LocallyNameless/Stlc/Basic.lean
@@ -102,7 +102,7 @@ lemma subst_aux (h : Δ ++ ⟨x, σ⟩ :: Γ ⊢ t ∶ τ) (der : Γ ⊢ s ∶ �
   case var x' τ ok mem => 
     simp only [subst_fvar]
     subst eq
-    cases (Context.wf_perm (by simp_all) ok : (⟨x, σ⟩ :: Δ ++ Γ)✓)
+    cases (Context.wf_perm (by simp) ok : (⟨x, σ⟩ :: Δ ++ Γ)✓)
     case cons ok_weak _ =>
     observe perm : (Γ ++ Δ).Perm (Δ ++ Γ)
     by_cases h : x = x' <;> simp only [h]

--- a/Cslib/Computability/LambdaCalculus/LocallyNameless/Stlc/Basic.lean
+++ b/Cslib/Computability/LambdaCalculus/LocallyNameless/Stlc/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Henson
 -/
 
-import Cslib.Computability.LambdaCalculus.LocallyNameless.Stlc.Context
+import Cslib.Computability.LambdaCalculus.LocallyNameless.Context
 import Cslib.Computability.LambdaCalculus.LocallyNameless.Untyped.Properties
 
 /-! # λ-calculus
@@ -23,6 +23,8 @@ universe u v
 
 variable {Var : Type u} {Base : Type v} [DecidableEq Var]
 
+open LambdaCalculus.LocallyNameless.Untyped Term
+
 namespace LambdaCalculus.LocallyNameless.Stlc
 
 /-- Types of the simply typed lambda calculus. -/
@@ -34,10 +36,9 @@ inductive Ty (Base : Type v)
 
 scoped infixr:70 " ⤳ " => Ty.arrow
 
-open Term Ty
+open Ty Context
 
 /-- An extrinsic typing derivation for locally nameless terms. -/
-@[aesop unsafe [constructors (rule_sets := [LambdaCalculus.LocallyNameless.ruleSet])]]
 inductive Typing : Context Var (Ty Base) → Term Var → Ty Base → Prop
   /-- Free variables, from a context judgement. -/
   | var : Γ✓ → ⟨x,σ⟩ ∈ Γ → Typing Γ (fvar x) σ
@@ -46,7 +47,9 @@ inductive Typing : Context Var (Ty Base) → Term Var → Ty Base → Prop
   /-- Function application. -/
   | app : Typing Γ t (σ ⤳ τ) → Typing Γ t' σ → Typing Γ (app t t') τ
 
-scoped notation:50 Γ " ⊢ " t " ∶" τ:arg => Typing Γ t τ
+attribute [scoped grind] Typing.var Typing.app
+
+scoped notation:50 Γ " ⊢ " t " ∶ " τ:arg => Typing Γ t τ
 
 namespace Typing
 
@@ -54,83 +57,67 @@ variable {Γ Δ Θ : Context Var (Ty Base)}
 
 omit [DecidableEq Var] in
 /-- Typing is preserved on permuting a context. -/
-theorem perm (ht : Γ ⊢ t ∶τ) (hperm : Γ.Perm Δ) : Δ ⊢ t ∶ τ := by 
-  revert Δ
-  induction ht <;> intros Δ p
-  case app => aesop
-  case var => 
-    have := @p.mem_iff
-    aesop
+theorem perm (ht : Γ ⊢ t ∶ τ) (hperm : Γ.Perm Δ) : Δ ⊢ t ∶ τ := by 
+  induction ht generalizing Δ
   case abs ih => 
     constructor
     intros x mem
-    exact ih x mem (by aesop)
+    exact ih x mem (by simp_all)
+  all_goals grind
 
 /-- Weakening of a typing derivation with an appended context. -/
-lemma weaken_aux : 
-    Γ ++ Δ ⊢ t ∶ τ → (Γ ++ Θ ++ Δ)✓ → (Γ ++ Θ ++ Δ) ⊢ t ∶ τ := by
-  generalize eq : Γ ++ Δ = Γ_Δ
-  intros h
-  revert Γ Δ Θ
-  induction h <;> intros Γ Δ Θ eq ok_Γ_Θ_Δ
-  case var => aesop
-  case app => aesop
+lemma weaken_aux (der : Γ ++ Δ ⊢ t ∶ τ) : (Γ ++ Θ ++ Δ)✓ → (Γ ++ Θ ++ Δ) ⊢ t ∶ τ := by
+  generalize eq : Γ ++ Δ = Γ_Δ at der
+  induction der generalizing Γ Δ Θ <;> intros ok_Γ_Θ_Δ
   case abs σ Γ' τ t xs ext ih =>
     apply Typing.abs (xs ∪ (Γ ++ Θ ++ Δ).dom)
     intros x _
-    have h : ⟨x, σ⟩ :: Γ ++ Δ = ⟨x, σ⟩ :: Γ' := by aesop
-    refine @ih x (by aesop) _ _ Θ h ?_
-    simp only [HasWellFormed.wf]
-    aesop
+    have h : ⟨x, σ⟩ :: Γ ++ Δ = ⟨x, σ⟩ :: Γ' := by grind
+    refine @ih x (by grind) _ _ Θ h ?_
+    simp_all [HasWellFormed.wf]
+  all_goals grind
 
 /-- Weakening of a typing derivation by an additional context. -/
-lemma weaken : Γ ⊢ t ∶ τ → (Γ ++ Δ)✓ → Γ ++ Δ ⊢ t ∶ τ := by
-  intros der ok
+lemma weaken (der : Γ ⊢ t ∶ τ) (ok : (Γ ++ Δ)✓) : Γ ++ Δ ⊢ t ∶ τ := by
   rw [←List.append_nil (Γ ++ Δ)] at *
   exact weaken_aux (by simp_all) ok
 
 omit [DecidableEq Var] in
 /-- Typing derivations exist only for locally closed terms. -/
-lemma lc : Γ ⊢ t ∶ τ → t.LC := by
-  intros h
-  induction h <;> constructor
+lemma lc (der : Γ ⊢ t ∶ τ) : t.LC := by
+  induction der <;> constructor
   case abs ih => exact ih
-  all_goals aesop
+  all_goals grind
 
 variable [HasFresh Var]
 
 open Term
 
 /-- Substitution for a context weakened by a single type between appended contexts. -/
-lemma subst_aux :
-    (Δ ++ ⟨x, σ⟩ :: Γ) ⊢ t ∶ τ →
-    Γ ⊢ s ∶ σ → 
-    (Δ ++ Γ) ⊢ (t [x := s]) ∶ τ := by
-  generalize  eq : Δ ++ ⟨x, σ⟩ :: Γ = Θ
-  intros h
-  revert Γ Δ
-  induction h <;> intros Γ Δ eq der
-  case app => aesop
+lemma subst_aux (h : Δ ++ ⟨x, σ⟩ :: Γ ⊢ t ∶ τ) (der : Γ ⊢ s ∶ σ) :
+    Δ ++ Γ ⊢ t[x := s] ∶ τ := by
+  generalize eq : Δ ++ ⟨x, σ⟩ :: Γ = Θ at h
+  induction h generalizing Γ Δ der
+  case app => grind
   case var x' τ ok mem => 
     simp only [subst_fvar]
-    rw [←eq] at mem
-    rw [←eq] at ok
-    cases (Context.wf_perm (by aesop) ok : (⟨x, σ⟩ :: Δ ++ Γ)✓)
+    subst eq
+    cases (Context.wf_perm (by simp_all) ok : (⟨x, σ⟩ :: Δ ++ Γ)✓)
     case cons ok_weak _ =>
     observe perm : (Γ ++ Δ).Perm (Δ ++ Γ)
     by_cases h : x = x' <;> simp only [h]
-    case neg => aesop
+    case neg => grind
     case pos nmem =>
-      subst h eq
+      subst h
       have nmem_Γ : ∀ γ, ⟨x, γ⟩ ∉ Γ := by
         intros γ _
-        exact nmem x (List.mem_keys.mpr ⟨γ, by aesop⟩) rfl
+        exact nmem x (List.mem_keys.mpr ⟨γ, by simp_all⟩) rfl
       have nmem_Δ : ∀ γ, ⟨x, γ⟩ ∉ Δ := by
         intros γ _
-        exact nmem x (List.mem_keys.mpr ⟨γ, by aesop⟩) rfl
+        exact nmem x (List.mem_keys.mpr ⟨γ, by simp_all⟩) rfl
       have eq' : τ = σ := by
         simp only [List.mem_append, List.mem_cons, Sigma.mk.injEq, heq_eq_eq] at mem
-        match mem with | _ => aesop
+        match mem with | _ => simp_all
       rw [eq']
       refine (weaken der ?_).perm perm
       exact Context.wf_perm (id (List.Perm.symm perm)) ok_weak
@@ -139,27 +126,23 @@ lemma subst_aux :
     intros x _
     rw [
       subst_def, 
-      subst_open_var _ _ _ _ (by aesop) der.lc,
-      show ⟨x, σ⟩ :: (Δ ++ Γ) = (⟨x, σ⟩ :: Δ) ++ Γ by aesop
+      ←subst_open_var _ _ _ _ (by grind) der.lc,
+      show ⟨x, σ⟩ :: (Δ ++ Γ) = (⟨x, σ⟩ :: Δ) ++ Γ by grind
       ]
-    apply ih <;> aesop
+    apply ih <;> grind
 
 /-- Substitution for a context weakened by a single type. -/
-lemma typing_subst_head : 
-    ⟨x, σ⟩ :: Γ ⊢ t ∶ τ  → Γ ⊢ s ∶ σ → Γ ⊢ (t [x := s]) ∶ τ := by
-  intros weak der
+lemma typing_subst_head (weak : ⟨x, σ⟩ :: Γ ⊢ t ∶ τ) (der : Γ ⊢ s ∶ σ) :
+    Γ ⊢ (t [x := s]) ∶ τ := by
   rw [←List.nil_append Γ]
   exact subst_aux weak der
 
 /-- Typing preservation for opening. -/
-@[aesop safe forward (rule_sets := [LambdaCalculus.LocallyNameless.ruleSet])]
-theorem preservation_open {xs : Finset Var} :
-  (∀ x ∉ xs, ⟨x, σ⟩ :: Γ ⊢ m ^ fvar x ∶ τ) → 
-  Γ ⊢ n ∶ σ → Γ ⊢ m ^ n ∶ τ
-  := by
-  intros mem der
+theorem preservation_open {xs : Finset Var}
+  (cofin : ∀ x ∉ xs, ⟨x, σ⟩ :: Γ ⊢ m ^ fvar x ∶ τ) (der : Γ ⊢ n ∶ σ) : 
+    Γ ⊢ m ^ n ∶ τ := by
   have ⟨fresh, _⟩ := fresh_exists <| free_union (map := Term.fv) Var
-  rw [subst_intro fresh n m (by aesop) der.lc]
-  exact typing_subst_head (mem fresh (by aesop)) der
+  rw [subst_intro fresh n m (by grind) der.lc]
+  exact typing_subst_head (by grind) der
 
 end LambdaCalculus.LocallyNameless.Stlc.Typing

--- a/Cslib/Computability/LambdaCalculus/LocallyNameless/Stlc/Safety.lean
+++ b/Cslib/Computability/LambdaCalculus/LocallyNameless/Stlc/Safety.lean
@@ -62,7 +62,7 @@ theorem preservation (der : Γ ⊢ t ∶ τ) (step : t ⭢βᶠ t') : Γ ⊢ t' 
   case abs.abs xs _ _ _ xs' _ => apply Typing.abs (xs ∪ xs'); grind
   case app.beta der _ _ _ der_l _ _ => 
     -- TODO: this is a regression from aesop, where `preservation_open` was a forward rule
-    cases der_l with | abs _ cofin => simp_all [preservation_open cofin der]
+    cases der_l with | abs _ cofin => simp [preservation_open cofin der]
   all_goals grind
 
 open scoped Term in

--- a/Cslib/Computability/LambdaCalculus/LocallyNameless/Stlc/Safety.lean
+++ b/Cslib/Computability/LambdaCalculus/LocallyNameless/Stlc/Safety.lean
@@ -59,7 +59,7 @@ open LambdaCalculus.LocallyNameless.Untyped.Term FullBeta
 @[scoped grind →]
 theorem preservation (der : Γ ⊢ t ∶ τ) (step : t ⭢βᶠ t') : Γ ⊢ t' ∶ τ := by
   induction der generalizing t' <;> cases step
-  case abs.abs xs _ _ _ xs' _ => apply Typing.abs (xs ∪ xs'); grind
+  case abs.abs xs _ _ _ xs' _ => apply Typing.abs (free_union Var); grind
   case app.beta der _ _ _ der_l _ _ => 
     -- TODO: this is a regression from aesop, where `preservation_open` was a forward rule
     cases der_l with | abs _ cofin => simp [preservation_open cofin der]

--- a/Cslib/Computability/LambdaCalculus/LocallyNameless/Stlc/Safety.lean
+++ b/Cslib/Computability/LambdaCalculus/LocallyNameless/Stlc/Safety.lean
@@ -24,9 +24,9 @@ Theorems in this file are namespaced by their respective reductions.
 
 universe u v
 
-namespace LambdaCalculus.LocallyNameless
+namespace LambdaCalculus.LocallyNameless.Stlc
 
-open Stlc Typing
+open Untyped Typing
 
 variable {Var : Type u} {Base : Type v} {R : Term Var → Term Var → Prop}
 
@@ -34,42 +34,44 @@ def PreservesTyping (R : Term Var → Term Var → Prop) (Base : Type v) :=
   ∀ {Γ t t'} {τ : Ty Base}, Γ ⊢ t ∶ τ → R t t' → Γ ⊢ t' ∶ τ
 
 /-- If a reduction preserves types, so does its reflexive transitive closure. -/
-@[aesop safe forward (rule_sets := [LambdaCalculus.LocallyNameless.ruleSet])]
+@[scoped grind →]
 theorem redex_preservesTyping : 
     PreservesTyping R Base → PreservesTyping (Relation.ReflTransGen R) Base := by
   intros _ _ _ _ _ _ redex
-  induction redex <;> aesop
+  induction redex <;> [grind; aesop]
 
 open Relation in
 /-- Confluence preserves type preservation. -/
-theorem confluence_preservesTyping {τ : Ty Base} : 
-    Confluence R → PreservesTyping R Base → Γ ⊢ a ∶ τ → 
-    (ReflTransGen R) a b → (ReflTransGen R) a c →
-    ∃ d, (ReflTransGen R) b d ∧ (ReflTransGen R) c d ∧ Γ ⊢ d ∶ τ := by
-  intros con p der ab ac
+theorem confluence_preservesTyping {τ : Ty Base}
+    (con : Confluence R) (p : PreservesTyping R Base) (der : Γ ⊢ a ∶ τ)
+    (ab : ReflTransGen R a b) (ac : ReflTransGen R a c) : 
+    ∃ d, ReflTransGen R b d ∧ ReflTransGen R c d ∧ Γ ⊢ d ∶ τ := by
   have ⟨d, bd, cd⟩ := con ab ac
   exact ⟨d, bd, cd, redex_preservesTyping p der (ab.trans bd)⟩
- 
+
 variable [HasFresh Var] [DecidableEq Var] {Γ : Context Var (Ty Base)}
 
-namespace Term.FullBeta
+namespace FullBeta
+
+open LambdaCalculus.LocallyNameless.Untyped.Term FullBeta
 
 /-- Typing preservation for full beta reduction. -/
-@[aesop safe forward (rule_sets := [LambdaCalculus.LocallyNameless.ruleSet])]
-theorem preservation : Γ ⊢ t ∶ τ → (t ⭢βᶠt') → Γ ⊢ t' ∶ τ := by
-  intros der
-  revert t'
-  induction der <;> intros t' step <;> cases step
-  case' abs.abs xs _ _ _ xs' _=> apply Typing.abs (xs ∪ xs')
-  case' app.beta der_l _ _ => cases der_l
-  all_goals aesop
+@[scoped grind →]
+theorem preservation (der : Γ ⊢ t ∶ τ) (step : t ⭢βᶠ t') : Γ ⊢ t' ∶ τ := by
+  induction der generalizing t' <;> cases step
+  case abs.abs xs _ _ _ xs' _ => apply Typing.abs (xs ∪ xs'); grind
+  case app.beta σ _ _ der _ _ _ der_l _ _ => 
+    -- TODO: this is a regression from aesop, where `preservation_open` was a forward rule
+    cases der_l with | abs L cofin => simp_all [preservation_open (σ := σ) (xs := L) cofin der]
+  all_goals grind
 
+open scoped Term in
 omit [HasFresh Var] [DecidableEq Var] in
 /-- A typed term either full beta reduces or is a value. -/
-theorem progress {t : Term Var} {τ : Ty Base} (ht : [] ⊢ t ∶τ) : t.Value ∨ ∃ t', t ⭢βᶠ t' := by
+theorem progress {t : Term Var} {τ : Ty Base} (ht : [] ⊢ t ∶ τ) : t.Value ∨ ∃ t', t ⭢βᶠ t' := by
   generalize eq : [] = Γ at ht
   induction ht
-  case var => aesop
+  case var => simp_all
   case abs xs mem ih =>
     left
     constructor
@@ -83,10 +85,12 @@ theorem progress {t : Term Var} {τ : Ty Base} (ht : [] ⊢ t ∶τ) : t.Value �
     -- if the lhs is a value, beta reduce the application
     next val =>
       cases val
-      next M M_abs_lc => exact ⟨M ^ N, FullBeta.beta M_abs_lc der_r.lc⟩
+      next M M_abs_lc => exact ⟨M ^ N, Term.FullBeta.beta M_abs_lc der_r.lc⟩
     -- otherwise, propogate the step to the lhs of the application
     next step =>
       obtain ⟨M', stepM⟩ := step
-      exact ⟨M'.app N, FullBeta.appR der_r.lc stepM⟩ 
+      exact ⟨M'.app N, Term.FullBeta.appR der_r.lc stepM⟩ 
 
-end LambdaCalculus.LocallyNameless.Term.FullBeta
+end FullBeta
+
+end LambdaCalculus.LocallyNameless.Stlc

--- a/Cslib/Computability/LambdaCalculus/LocallyNameless/Stlc/Safety.lean
+++ b/Cslib/Computability/LambdaCalculus/LocallyNameless/Stlc/Safety.lean
@@ -60,9 +60,9 @@ open LambdaCalculus.LocallyNameless.Untyped.Term FullBeta
 theorem preservation (der : Γ ⊢ t ∶ τ) (step : t ⭢βᶠ t') : Γ ⊢ t' ∶ τ := by
   induction der generalizing t' <;> cases step
   case abs.abs xs _ _ _ xs' _ => apply Typing.abs (xs ∪ xs'); grind
-  case app.beta σ _ _ der _ _ _ der_l _ _ => 
+  case app.beta der _ _ _ der_l _ _ => 
     -- TODO: this is a regression from aesop, where `preservation_open` was a forward rule
-    cases der_l with | abs L cofin => simp_all [preservation_open (σ := σ) (xs := L) cofin der]
+    cases der_l with | abs _ cofin => simp_all [preservation_open cofin der]
   all_goals grind
 
 open scoped Term in

--- a/Cslib/Computability/LambdaCalculus/LocallyNameless/Untyped/AesopRuleset.lean
+++ b/Cslib/Computability/LambdaCalculus/LocallyNameless/Untyped/AesopRuleset.lean
@@ -1,3 +1,0 @@
-import Aesop
-
-declare_aesop_rule_sets [LambdaCalculus.LocallyNameless.ruleSet] (default := true)

--- a/Cslib/Computability/LambdaCalculus/LocallyNameless/Untyped/Basic.lean
+++ b/Cslib/Computability/LambdaCalculus/LocallyNameless/Untyped/Basic.lean
@@ -6,7 +6,6 @@ Authors: Chris Henson
 
 import Cslib.Data.HasFresh
 import Cslib.Syntax.HasSubstitution
-import Cslib.Computability.LambdaCalculus.LocallyNameless.Untyped.AesopRuleset
 
 /-! # λ-calculus
 
@@ -24,7 +23,7 @@ universe u
 
 variable {Var : Type u} [HasFresh Var] [DecidableEq Var]
 
-namespace LambdaCalculus.LocallyNameless
+namespace LambdaCalculus.LocallyNameless.Untyped
 
 /-- Syntax of locally nameless lambda terms, with free variables over `Var`. -/
 inductive Term (Var : Type u)
@@ -40,6 +39,7 @@ inductive Term (Var : Type u)
 namespace Term
 
 /-- Variable opening of the ith bound variable. -/
+@[scoped grind =]
 def openRec (i : ℕ) (sub : Term Var) : Term Var → Term Var
 | bvar i' => if i = i' then sub else bvar i'
 | fvar x  => fvar x
@@ -48,24 +48,22 @@ def openRec (i : ℕ) (sub : Term Var) : Term Var → Term Var
 
 scoped notation:68 e "⟦" i " ↝ " sub "⟧"=> Term.openRec i sub e
 
-@[aesop norm (rule_sets := [LambdaCalculus.LocallyNameless.ruleSet])]
 lemma openRec_bvar : (bvar i')⟦i ↝ s⟧ = if i = i' then s else bvar i' := by rfl
 
-@[aesop norm (rule_sets := [LambdaCalculus.LocallyNameless.ruleSet])]
 lemma openRec_fvar : (fvar x)⟦i ↝ s⟧ = fvar x := by rfl
 
-@[aesop norm (rule_sets := [LambdaCalculus.LocallyNameless.ruleSet])]
 lemma openRec_app : (app l r)⟦i ↝ s⟧ = app (l⟦i ↝ s⟧) (r⟦i ↝ s⟧) := by rfl
 
-@[aesop norm (rule_sets := [LambdaCalculus.LocallyNameless.ruleSet])]
 lemma openRec_abs : M.abs⟦i ↝ s⟧ = M⟦i + 1 ↝ s⟧.abs := by rfl
 
 /-- Variable opening of the closest binding. -/
+@[scoped grind =]
 def open' {X} (e u):= @Term.openRec X 0 u e
 
-infixr:80 " ^ " => Term.open'
+scoped infixr:80 " ^ " => Term.open'
 
 /-- Variable closing, replacing a free `fvar x` with `bvar k` -/
+@[scoped grind =]
 def closeRec (k : ℕ) (x : Var) : Term Var → Term Var
 | fvar x' => if x = x' then bvar k else fvar x'
 | bvar i  => bvar i
@@ -76,28 +74,14 @@ scoped notation:68 e "⟦" k " ↜ " x "⟧"=> Term.closeRec k x e
 
 variable {x : Var}
 
-omit [HasFresh Var] in
-@[aesop norm (rule_sets := [LambdaCalculus.LocallyNameless.ruleSet])]
-lemma closeRec_bvar : (bvar i)⟦k ↜ x⟧ = bvar i := by rfl
-
-omit [HasFresh Var] in
-@[aesop norm (rule_sets := [LambdaCalculus.LocallyNameless.ruleSet])]
-lemma closeRec_fvar : (fvar x')⟦k ↜ x⟧ = if x = x' then bvar k else fvar x' := by rfl
-
-omit [HasFresh Var] in
-@[aesop norm (rule_sets := [LambdaCalculus.LocallyNameless.ruleSet])]
-lemma closeRec_app : (app l r)⟦k ↜ x⟧ = app (l⟦k ↜ x⟧) (r⟦k ↜ x⟧) := by rfl
-
-omit [HasFresh Var] in
-@[aesop norm (rule_sets := [LambdaCalculus.LocallyNameless.ruleSet])]
-lemma closeRec_abs : t.abs⟦k ↜ x⟧ = t⟦k + 1 ↜ x⟧.abs := by rfl
-
 /-- Variable closing of the closest binding. -/
+@[scoped grind =]
 def close {Var} [DecidableEq Var] (e u):= @Term.closeRec Var _ 0 u e
 
-infixr:80 " ^* " => Term.close
+scoped infixr:80 " ^* " => Term.close
 
 /- Substitution of a free variable to a term. -/
+@[scoped grind =]
 def subst (m : Term Var) (x : Var) (sub : Term Var) : Term Var :=
   match m with
   | bvar i  => bvar i
@@ -109,28 +93,8 @@ def subst (m : Term Var) (x : Var) (sub : Term Var) : Term Var :=
 instance instHasSubstitutionTerm : HasSubstitution (Term Var) Var where
   subst := Term.subst
 
-omit [HasFresh Var] in
-@[aesop norm (rule_sets := [LambdaCalculus.LocallyNameless.ruleSet])]
-lemma subst_bvar {n : Term Var} : (bvar i)[x := n] = bvar i := by rfl
-
-omit [HasFresh Var] in
-@[aesop norm (rule_sets := [LambdaCalculus.LocallyNameless.ruleSet])]
-lemma subst_fvar : (fvar x')[x := n] = if x = x' then n else fvar x' := by rfl
-
-omit [HasFresh Var] in
-@[aesop norm (rule_sets := [LambdaCalculus.LocallyNameless.ruleSet])]
-lemma subst_app {l r : Term Var} : (app l r)[x := n] = app (l[x := n]) (r[x := n]) := by rfl
-
-omit [HasFresh Var] in
-@[aesop norm (rule_sets := [LambdaCalculus.LocallyNameless.ruleSet])]
-lemma subst_abs {M : Term Var} : M.abs[x := n] = M[x := n].abs := by rfl
-
-omit [HasFresh Var] in
-@[aesop norm (rule_sets := [LambdaCalculus.LocallyNameless.ruleSet])]
-lemma subst_def (m : Term Var) (x : Var) (n : Term Var) : m.subst x n = m[x := n] := by rfl
-
 /-- Free variables of a term. -/
-@[simp]
+@[simp, scoped grind =]
 def fv : Term Var → Finset Var
 | bvar _ => {}
 | fvar x => {x}
@@ -138,13 +102,40 @@ def fv : Term Var → Finset Var
 | app l r => l.fv ∪ r.fv
 
 /-- Locally closed terms. -/
-@[aesop safe (rule_sets := [LambdaCalculus.LocallyNameless.ruleSet]) [constructors]]
 inductive LC : Term Var → Prop
 | fvar (x)  : LC (fvar x)
-| abs (L : Finset Var) (e : Term Var) : (∀ x : Var, x ∉ L → LC (e ^ fvar x)) → LC (abs e)
+| abs (L : Finset Var) (e : Term Var) : (∀ x ∉ L, LC (e ^ fvar x)) → LC (abs e)
 | app {l r} : l.LC → r.LC → LC (app l r)
+
+attribute [scoped grind] LC.fvar LC.app
 
 inductive Value : Term Var → Prop
 | abs (e : Term Var) : e.abs.LC → e.abs.Value
 
-end LambdaCalculus.LocallyNameless.Term
+section
+
+omit [HasFresh Var]
+
+lemma closeRec_bvar : (bvar i)⟦k ↜ x⟧ = bvar i := by rfl
+
+lemma closeRec_fvar : (fvar x')⟦k ↜ x⟧ = if x = x' then bvar k else fvar x' := by rfl
+
+lemma closeRec_app : (app l r)⟦k ↜ x⟧ = app (l⟦k ↜ x⟧) (r⟦k ↜ x⟧) := by rfl
+
+lemma closeRec_abs : t.abs⟦k ↜ x⟧ = t⟦k + 1 ↜ x⟧.abs := by rfl
+
+lemma subst_bvar {n : Term Var} : (bvar i)[x := n] = bvar i := by rfl
+
+lemma subst_fvar : (fvar x')[x := n] = if x = x' then n else fvar x' := by rfl
+
+lemma subst_app {l r : Term Var} : (app l r)[x := n] = app (l[x := n]) (r[x := n]) := by rfl
+
+lemma subst_abs {M : Term Var} : M.abs[x := n] = M[x := n].abs := by rfl
+
+lemma subst_def (m : Term Var) (x : Var) (n : Term Var) : m.subst x n = m[x := n] := by rfl
+
+attribute [scoped grind =] subst_bvar subst_fvar subst_app subst_abs subst_def
+
+end
+
+end LambdaCalculus.LocallyNameless.Untyped.Term

--- a/Cslib/Computability/LambdaCalculus/LocallyNameless/Untyped/FullBeta.lean
+++ b/Cslib/Computability/LambdaCalculus/LocallyNameless/Untyped/FullBeta.lean
@@ -22,7 +22,7 @@ universe u
 
 variable {Var : Type u} 
 
-namespace LambdaCalculus.LocallyNameless.Term
+namespace LambdaCalculus.LocallyNameless.Untyped.Term
 
 /-- A single β-reduction step. -/
 @[reduction_sys fullBetaRs "βᶠ"]
@@ -38,23 +38,32 @@ inductive FullBeta : Term Var → Term Var → Prop
 
 namespace FullBeta
 
+attribute [scoped grind] appL appR
+
 variable {M M' N N' : Term Var}
 
+--- TODO: I think this could be generated along with the ReductionSystem
+@[scoped grind _=_]
+private lemma fullBetaRs_Red_eq : M ⭢βᶠ N ↔ FullBeta M N := by
+  have : (@fullBetaRs Var).Red = FullBeta := by rfl
+  simp_all
+
 /-- The left side of a reduction is locally closed. -/
+@[scoped grind →]
 lemma step_lc_l (step : M ⭢βᶠ M') : LC M := by
   induction step <;> constructor
   all_goals assumption
 
 /-- Left congruence rule for application in multiple reduction. -/
-theorem redex_app_l_cong : (M ↠βᶠ M') → LC N → (app M N ↠βᶠ app M' N) := by
-  intros redex lc_N 
+@[scoped grind ←]
+theorem redex_app_l_cong (redex : M ↠βᶠ M') (lc_N : LC N) : app M N ↠βᶠ app M' N := by
   induction' redex
   case refl => rfl
   case tail ih r => exact Relation.ReflTransGen.tail r (appR lc_N ih)
 
 /-- Right congruence rule for application in multiple reduction. -/
-theorem redex_app_r_cong : (M ↠βᶠ M') → LC N → (app N M ↠βᶠ app N M') := by
-  intros redex lc_N 
+@[scoped grind ←]
+theorem redex_app_r_cong (redex : M ↠βᶠ M') (lc_N : LC N) : app N M ↠βᶠ app N M' := by
   induction' redex
   case refl => rfl
   case tail ih r => exact Relation.ReflTransGen.tail r (appL lc_N ih)
@@ -62,62 +71,43 @@ theorem redex_app_r_cong : (M ↠βᶠ M') → LC N → (app N M ↠βᶠ app N 
 variable [HasFresh Var] [DecidableEq Var]
 
 /-- The right side of a reduction is locally closed. -/
+@[scoped grind →]
 lemma step_lc_r (step : M ⭢βᶠ M') : LC M' := by
   induction step
-  case beta => apply beta_lc <;> assumption
-  all_goals try constructor <;> assumption 
+  case' abs => constructor; assumption
+  all_goals grind
 
 /-- Substitution respects a single reduction step. -/
-lemma redex_subst_cong (s s' : Term Var) (x y : Var) : 
-    s ⭢βᶠ s' → s [ x := fvar y ] ⭢βᶠ s' [ x := fvar y ] := by
-  intros step
+lemma redex_subst_cong (s s' : Term Var) (x y : Var) (step : s ⭢βᶠ s') : 
+    s [ x := fvar y ] ⭢βᶠ s' [ x := fvar y ] := by
   induction step
-  case appL ih => exact appL (subst_lc (by assumption) (by constructor)) ih 
-  case appR ih => exact appR (subst_lc (by assumption) (by constructor)) ih  
   case beta m n abs_lc n_lc => 
     cases abs_lc with | abs xs _ mem =>
-      simp only [open']
-      rw [subst_open x (fvar y) 0 n m (by constructor)]
-      refine beta ?_ (subst_lc n_lc (by constructor))
+      rw [subst_open x (fvar y) n m (by grind)]
+      refine beta ?_ (by grind)
       exact subst_lc (LC.abs xs m mem) (LC.fvar y)
   case abs m' m xs mem ih => 
-    apply abs ({x} ∪ xs)
-    intros z z_mem
-    simp only [open']
-    rw [
-      subst_def, subst_def,
-      ←subst_fresh x (fvar z) (fvar y), ←subst_open x (fvar y) 0 (fvar z) m (by constructor),
-      subst_fresh x (fvar z) (fvar y), ←subst_fresh x (fvar z) (fvar y),
-      ←subst_open x (fvar y) 0 (fvar z) m' (by constructor), subst_fresh x (fvar z) (fvar y)
-    ]
-    all_goals aesop
+    apply abs (free_union Var)
+    grind
+  all_goals grind
 
 /-- Abstracting then closing preserves a single reduction. -/
-lemma step_abs_close {x : Var} : (M ⭢βᶠ M') → (M⟦0 ↜ x⟧.abs ⭢βᶠ M'⟦0 ↜ x⟧.abs) := by
-  intros step
+lemma step_abs_close {x : Var} (step : M ⭢βᶠ M') : M⟦0 ↜ x⟧.abs ⭢βᶠ M'⟦0 ↜ x⟧.abs := by
   apply abs ∅
-  intros y _
-  simp only [open']
-  repeat rw [open_close_to_subst]
-  · exact redex_subst_cong M M' x y step
-  · exact step_lc_r step
-  · exact step_lc_l step
+  grind [redex_subst_cong]
 
 /-- Abstracting then closing preserves multiple reductions. -/
-lemma redex_abs_close {x : Var} : (M ↠βᶠ M') → (M⟦0 ↜ x⟧.abs ↠βᶠ M'⟦0 ↜ x⟧.abs) :=  by
-  intros step
+lemma redex_abs_close {x : Var} (step : M ↠βᶠ M') : (M⟦0 ↜ x⟧.abs ↠βᶠ M'⟦0 ↜ x⟧.abs) :=  by
   induction step using Relation.ReflTransGen.trans_induction_on
   case refl => rfl
   case single ih => exact Relation.ReflTransGen.single (step_abs_close ih)
   case trans l r => exact .trans l r
 
 /-- Multiple reduction of opening implies multiple reduction of abstraction. -/
-theorem redex_abs_cong (xs : Finset Var) : 
-    (∀ x ∉ xs, (M ^ fvar x) ↠βᶠ (M' ^ fvar x)) → M.abs ↠βᶠ M'.abs := by
-  intros mem
+theorem redex_abs_cong (xs : Finset Var) (cofin : ∀ x ∉ xs, (M ^ fvar x) ↠βᶠ (M' ^ fvar x)) : 
+    M.abs ↠βᶠ M'.abs := by
   have ⟨fresh, _⟩ := fresh_exists <| free_union (map := fv) Var
   rw [←open_close fresh M 0 ?_, ←open_close fresh M' 0 ?_]
-  · exact redex_abs_close (mem fresh (by aesop))
-  all_goals aesop
+  all_goals grind [redex_abs_close]
 
-end LambdaCalculus.LocallyNameless.Term.FullBeta
+end LambdaCalculus.LocallyNameless.Untyped.Term.FullBeta

--- a/Cslib/Computability/LambdaCalculus/LocallyNameless/Untyped/FullBeta.lean
+++ b/Cslib/Computability/LambdaCalculus/LocallyNameless/Untyped/FullBeta.lean
@@ -107,7 +107,7 @@ lemma redex_abs_close {x : Var} (step : M ↠βᶠ M') : (M⟦0 ↜ x⟧.abs ↠
 theorem redex_abs_cong (xs : Finset Var) (cofin : ∀ x ∉ xs, (M ^ fvar x) ↠βᶠ (M' ^ fvar x)) : 
     M.abs ↠βᶠ M'.abs := by
   have ⟨fresh, _⟩ := fresh_exists <| free_union (map := fv) Var
-  rw [←open_close fresh M 0 ?_, ←open_close fresh M' 0 ?_]
+  rw [open_close fresh M 0 ?_, open_close fresh M' 0 ?_]
   all_goals grind [redex_abs_close]
 
 end LambdaCalculus.LocallyNameless.Untyped.Term.FullBeta

--- a/Cslib/Computability/LambdaCalculus/LocallyNameless/Untyped/FullBetaConfluence.lean
+++ b/Cslib/Computability/LambdaCalculus/LocallyNameless/Untyped/FullBetaConfluence.lean
@@ -115,7 +115,7 @@ lemma para_subst (x : Var) (pm : M ⭢ₚ M') (pn : N ⭢ₚ N') : M[x := N] ⭢
     refine Parallel.beta (free_union Var) ?_ ?_ <;> grind
   case app => constructor <;> assumption
   case abs u u' xs mem ih => 
-    apply Parallel.abs (xs ∪ {x})
+    apply Parallel.abs (free_union Var)
     grind
 
 /-- Parallel substitution respects closing and opening. -/
@@ -162,7 +162,7 @@ theorem para_diamond : Diamond (@Parallel Var) := by
         exists (t'' ^* x) ^ t'
         constructor
         · grind
-        · apply Parallel.beta ((s1'' ^ fvar x).fv ∪ t''.fv ∪ {x}) <;> grind
+        · apply Parallel.beta (free_union (map := fv) Var) <;> grind
     case beta u1' u2' xs' mem' s2pu2' => 
       have ⟨x, qx⟩ := fresh_exists (xs ∪ xs' ∪ free_union (map := fv) Var)
       simp only [Finset.union_assoc, Finset.mem_union, not_or] at qx

--- a/Cslib/Computability/LambdaCalculus/LocallyNameless/Untyped/FullBetaConfluence.lean
+++ b/Cslib/Computability/LambdaCalculus/LocallyNameless/Untyped/FullBetaConfluence.lean
@@ -15,11 +15,10 @@ universe u
 
 variable {Var : Type u} 
 
-namespace LambdaCalculus.LocallyNameless.Term
+namespace LambdaCalculus.LocallyNameless.Untyped.Term
 
 /-- A parallel β-reduction step. -/
-@[aesop safe (rule_sets := [LambdaCalculus.LocallyNameless.ruleSet]) [constructors],
-  reduction_sys paraRs "ₚ"]
+@[reduction_sys paraRs "ₚ"]
 inductive Parallel : Term Var → Term Var → Prop
 /-- Free variables parallel step to themselves. -/
 | fvar (x : Var) : Parallel (fvar x) (fvar x)
@@ -34,73 +33,71 @@ inductive Parallel : Term Var → Term Var → Prop
     Parallel n n' → 
     Parallel (app (abs m) n) (m' ^ n')
 
--- TODO: I think this could be generated along with `para_rs`
-lemma para_rs_Red_eq {α} : (@paraRs α).Red = Parallel := by rfl
+open Parallel
+
+attribute [scoped grind] Parallel.fvar Parallel.app
+attribute [scoped grind cases] Parallel
 
 variable {M M' N N' : Term Var}
 
+--- TODO: I think this could be generated along with the ReductionSystem
+@[scoped grind _=_]
+private lemma para_rs_Red_eq : M ⭢ₚ N ↔ Parallel M N := by
+  have : (@paraRs Var).Red = Parallel := by rfl
+  simp_all
+
 /-- The left side of a parallel reduction is locally closed. -/
-@[aesop unsafe (rule_sets := [LambdaCalculus.LocallyNameless.ruleSet])]
+@[scoped grind]
 lemma para_lc_l (step : M ⭢ₚ N) : LC M  := by
   induction step
   case abs _ _ xs _ ih => exact LC.abs xs _ ih
   case beta => refine LC.app (LC.abs ?_ _ ?_) ?_ <;> assumption
-  all_goals constructor <;> assumption
+  all_goals grind
 
 /-- Parallel reduction is reflexive for locally closed terms. -/
-@[aesop safe (rule_sets := [LambdaCalculus.LocallyNameless.ruleSet])]
+@[scoped grind]
 lemma Parallel.lc_refl (M : Term Var) (lc : LC M) : M ⭢ₚ M := by
   induction lc
   all_goals constructor <;> assumption
 
--- TODO: better ways to handle this?
--- The problem is that sometimes when we apply a theorem we get out of our notation, so aesop can't
--- see they are the same, including constructors.
-@[aesop safe (rule_sets := [LambdaCalculus.LocallyNameless.ruleSet])]
-lemma Parallel.lc_refl' (M : Term Var) : LC M → Parallel M M := Parallel.lc_refl M
-
 variable [HasFresh Var] [DecidableEq Var]
 
 /-- The right side of a parallel reduction is locally closed. -/
-@[aesop unsafe (rule_sets := [LambdaCalculus.LocallyNameless.ruleSet])]
+@[scoped grind]
 lemma para_lc_r (step : M ⭢ₚ N) : LC N := by
   induction step
   case abs _ _ xs _ ih => exact LC.abs xs _ ih
   case beta => refine beta_lc (LC.abs ?_ _ ?_) ?_ <;> assumption
-  all_goals constructor <;> assumption
+  all_goals grind
 
 omit [HasFresh Var] [DecidableEq Var] in
 /-- A single β-reduction implies a single parallel reduction. -/
 lemma step_to_para (step : M ⭢βᶠ N) : M ⭢ₚ N := by
-  induction step <;> simp only [para_rs_Red_eq]
-  case beta _ abs_lc _ => cases abs_lc with | abs xs _ => 
-    apply Parallel.beta xs <;> intros <;> apply Parallel.lc_refl <;> aesop
-  all_goals aesop (config := {enableSimp := false})
+  induction step
+  case beta _ abs_lc _ => cases abs_lc with | abs xs _ => apply Parallel.beta xs <;> grind
+  case abs xs _ _ => apply Parallel.abs xs; grind
+  all_goals grind
 
 open FullBeta in
 /-- A single parallel reduction implies a multiple β-reduction. -/
 lemma para_to_redex (para : M ⭢ₚ N) : M ↠βᶠ N := by
   induction para
   case fvar => constructor
-  case app _ _ _ _ l_para m_para redex_l redex_m =>
-    trans
-    · exact redex_app_l_cong redex_l (para_lc_l m_para)
-    exact redex_app_r_cong redex_m (para_lc_r l_para)
+  case app L L' R R' l_para m_para redex_l redex_m =>
+    refine .trans (?_ : L.app R ↠βᶠ L'.app R) (?_ : L'.app R ↠βᶠ L'.app R') <;> grind
   case abs t t' xs _ ih =>
     apply redex_abs_cong xs
-    intros x mem
-    exact ih x mem
+    grind
   case beta m m' n n' xs para_ih para_n redex_ih redex_n =>
     have m'_abs_lc : LC m'.abs := by
       apply LC.abs xs
-      intros _ mem
-      exact para_lc_r (para_ih _ mem)
+      grind
     calc
       m.abs.app n ↠βᶠ 
       m'.abs.app n := 
         redex_app_l_cong (redex_abs_cong xs (fun _ mem ↦ redex_ih _ mem)) (para_lc_l para_n)
-      _           ↠βᶠ m'.abs.app n' := redex_app_r_cong redex_n m'_abs_lc
-      _           ⭢βᶠ m' ^ n'       := beta m'_abs_lc (para_lc_r para_n)
+      _           ↠βᶠ m'.abs.app n' := by grind
+      _           ⭢βᶠ m' ^ n'       := beta m'_abs_lc (by grind)
 
 /-- Multiple parallel reduction is equivalent to multiple β-reduction. -/
 theorem parachain_iff_redex : M ↠ₚ N ↔ M ↠βᶠ N := by
@@ -109,49 +106,27 @@ theorem parachain_iff_redex : M ↠ₚ N ↔ M ↠βᶠ N := by
   case chain_redex.tail para  redex => exact Relation.ReflTransGen.trans redex (para_to_redex para)
 
 /-- Parallel reduction respects substitution. -/
+@[scoped grind]
 lemma para_subst (x : Var) (pm : M ⭢ₚ M') (pn : N ⭢ₚ N') : M[x := N] ⭢ₚ M'[x := N'] := by
   induction pm
-  case fvar => aesop
-  case beta _ _ _ _ xs _ _ ih _ => 
-    simp only [open']
-    rw [subst_open _ _ _ _ _ (para_lc_r pn)]
-    refine Parallel.beta (xs ∪ {x}) ?_ (by assumption)
-    · intros y ymem
-      simp only [Finset.mem_union, Finset.mem_singleton, not_or] at ymem
-      push_neg at ymem
-      rw [
-        subst_def, 
-        subst_open_var _ _ _ _ _ (para_lc_r pn), 
-        subst_open_var _ _ _ _ _ (para_lc_l pn)
-      ] <;> aesop
+  case fvar => grind
+  case beta => 
+    rw [subst_open _ _ _ _ (by grind)]
+    refine Parallel.beta (free_union Var) ?_ ?_ <;> grind
   case app => constructor <;> assumption
   case abs u u' xs mem ih => 
     apply Parallel.abs (xs ∪ {x})
-    intros y ymem
-    simp only [Finset.mem_union, Finset.mem_singleton, not_or] at ymem
-    repeat rw [subst_def]
-    push_neg at ymem
-    rw [
-      subst_open_var _ _ _ _ ?_ (para_lc_l pn), 
-      subst_open_var _ _ _ _ ?_ (para_lc_r pn)
-    ] <;> aesop
+    grind
 
 /-- Parallel substitution respects closing and opening. -/
 lemma para_open_close (x y z) (para : M ⭢ₚ M') (_ : y ∉ M.fv ∪ M'.fv ∪ {x}) :
-    M⟦z ↜ x⟧⟦z ↝ fvar y⟧ ⭢ₚ M'⟦z ↜ x⟧⟦z ↝ fvar y⟧ := by
-  simp only [Finset.union_assoc, Finset.mem_union, Finset.mem_singleton, not_or] at *
-  rw [open_close_to_subst _ _ _ _ (para_lc_l para), open_close_to_subst _ _ _ _ (para_lc_r para)]
-  apply para_subst _ para
-  constructor
+    M⟦z ↜ x⟧⟦z ↝ fvar y⟧ ⭢ₚ M'⟦z ↜ x⟧⟦z ↝ fvar y⟧ := by grind
 
 /-- Parallel substitution respects fresh opening. -/
 lemma para_open_out (L : Finset Var) (mem : ∀ x, x ∉ L → (M ^ fvar x) ⭢ₚ N ^ fvar x)
     (para : M' ⭢ₚ N') : (M ^ M') ⭢ₚ (N ^ N') := by
   let ⟨x, _⟩ := fresh_exists <| free_union (map := fv) Var
-  rw [subst_intro x M' _ ?_ (para_lc_l para), subst_intro x N' _ ?_ (para_lc_r para)]
-  · refine para_subst x (mem x ?_) para
-    aesop
-  all_goals aesop
+  grind
 
 -- TODO: the Takahashi translation would be a much nicer and shorter proof, but I had difficultly
 -- writing it for locally nameless terms.
@@ -162,74 +137,60 @@ theorem para_diamond : Diamond (@Parallel Var) := by
   intros t t1 t2 tpt1
   revert t2
   induction tpt1 <;> intros t2 tpt2
-  case fvar x => exact ⟨t2, by aesop⟩
+  case fvar x => exact ⟨t2, by grind⟩
   case abs s1 s2' xs mem ih => 
     cases tpt2
     case abs t2' xs' mem' =>
-      have ⟨x, qx⟩ := fresh_exists (xs ∪ xs' ∪ t2'.fv ∪ s2'.fv)
+      have ⟨x, qx⟩ := fresh_exists (xs ∪ xs' ∪ free_union (map := fv) Var)
       simp only [Finset.union_assoc, Finset.mem_union, not_or] at qx
-      have ⟨q1, q2, q3, q4⟩ := qx
-      have ⟨t', qt'_l, qt'_r⟩ := ih x q1 (mem' _ q2)
+      have ⟨q1, q2, _⟩ := qx
+      have ⟨t', _⟩ := ih x q1 (mem' _ q2)
       exists abs (t' ^* x)
       constructor 
-      <;> [let z := s2'; let z := t2']
-      <;> apply Parallel.abs ((z ^ fvar x).fv ∪ t'.fv ∪ {x})
-      <;> intros y qy <;> simp only [open', close]
-      <;> [rw [←open_close x _ 0 q4]; rw [←open_close x _ 0 q3]] 
-      <;> refine para_open_close x y 0 ?_ qy <;> [exact qt'_l; exact qt'_r]
+      <;> [let z := s2' ^ fvar x; let z := t2' ^ fvar x]
+      <;> apply Parallel.abs (free_union (map := fv) Var) <;> grind
   case beta s1 s1' s2 s2' xs mem ps ih1 ih2 => 
     cases tpt2
     case app u2 u2' s1pu2 s2pu2' => 
       cases s1pu2
       case abs s1'' xs' mem' =>
-        have ⟨x, qx⟩ := fresh_exists (xs ∪ xs' ∪ s1''.fv ∪ s1'.fv)
+        have ⟨x, qx⟩ := fresh_exists (xs ∪ xs' ∪ free_union (map := fv) Var)
         simp only [Finset.union_assoc, Finset.mem_union, not_or] at qx
-        obtain ⟨q1, q2, q3, q4⟩ := qx
-        have ⟨t', qt'_l, qt'_r⟩ := ih2 s2pu2'
-        have ⟨t'', qt''_l, qt''_r⟩ := @ih1 x q1 _ (mem' _ q2)
+        obtain ⟨q1, q2, _⟩ := qx
+        have ⟨t', _⟩ := ih2 s2pu2'
+        have ⟨t'', _⟩ := @ih1 x q1 _ (mem' _ q2)
         exists (t'' ^* x) ^ t'
         constructor
-        · rw [subst_intro x s2' _ q4 (para_lc_l qt'_l), 
-              subst_intro x t' _ (close_var_not_fvar x t'') (para_lc_r qt'_l)]
-          simp only [open', close]
-          rw [close_open _ _ _ (para_lc_r qt''_l)]
-          exact para_subst x qt''_l qt'_l
-        · refine Parallel.beta ((s1'' ^ fvar x).fv ∪ t''.fv ∪ {x}) ?_ (by aesop)
-          intros y qy
-          rw [←open_close x s1'' 0 (by aesop)]
-          apply para_open_close <;> aesop
+        · grind
+        · apply Parallel.beta ((s1'' ^ fvar x).fv ∪ t''.fv ∪ {x}) <;> grind
     case beta u1' u2' xs' mem' s2pu2' => 
-      have ⟨x, qx⟩ := fresh_exists (xs ∪ xs' ∪ u1'.fv ∪ s1'.fv ∪ s2'.fv ∪ u2'.fv)
+      have ⟨x, qx⟩ := fresh_exists (xs ∪ xs' ∪ free_union (map := fv) Var)
       simp only [Finset.union_assoc, Finset.mem_union, not_or] at qx
-      have ⟨q1, q2, q3, q4, q5, q6⟩ := qx
-      have ⟨t', qt'_l, qt'_r⟩ := ih2 s2pu2'
-      have ⟨t'', qt''_l, qt''_r⟩ := @ih1 x q1 _ (mem' _ q2)
+      have ⟨q1, q2, _⟩ := qx
+      have ⟨t', _⟩ := ih2 s2pu2'
+      have ⟨t'', _⟩ := @ih1 x q1 _ (mem' _ q2)
       refine ⟨t'' [x := t'], ?_⟩
-      have : _ ∧ _ := ⟨para_subst x qt''_l qt'_l, para_subst x qt''_r qt'_r⟩
-      rw [subst_intro x u2' u1' _ (para_lc_l qt'_r), subst_intro x s2' s1' _ (para_lc_l qt'_l)]
-      all_goals aesop
+      grind
   case app s1 s1' s2 s2' s1ps1' _ ih1 ih2  =>
     cases tpt2
     case app u1 u2' s1 s2 =>
       have ⟨l, _, _⟩ := ih1 s1
       have ⟨r, _, _⟩ := ih2 s2
-      exact ⟨app l r, by aesop⟩
+      exact ⟨app l r, by grind⟩
     case beta t1' u1' u2' xs mem s2pu2' => 
       cases s1ps1'
       case abs s1'' xs' mem' =>
-        have ⟨x, qx⟩ := fresh_exists (xs ∪ xs' ∪ s1''.fv ∪ u1'.fv)
+        have ⟨x, qx⟩ := fresh_exists (xs ∪ xs' ∪ free_union (map := fv) Var)
         simp only [Finset.union_assoc, Finset.mem_union, not_or] at qx
-        obtain ⟨q1, q2, q3, q4⟩ := qx
+        obtain ⟨q1, q2, _⟩ := qx
         have ⟨t', qt'_l, qt'_r⟩ := ih2 s2pu2'
         have ⟨t'', qt''_l, qt''_r⟩ := @ih1 (abs u1') (Parallel.abs xs mem)
         cases qt''_l
         next w1 xs'' mem'' =>
         cases qt''_r
         case abs xs''' mem''' =>
-          exists w1 ^ t'
-          constructor
-          · aesop (config := {enableSimp := false})
-          · exact para_open_out xs''' mem''' qt'_r
+          refine ⟨w1 ^ t', ?_, para_open_out xs''' mem''' qt'_r⟩
+          apply Parallel.beta (free_union Var) <;> grind
 
 /-- Parallel reduction is confluent. -/
 theorem para_confluence : Confluence (@Parallel Var) := 
@@ -244,4 +205,4 @@ theorem confluence_beta : Confluence (@FullBeta Var) := by
   rw [←eq]
   exact @para_confluence Var _ _
 
-end LambdaCalculus.LocallyNameless.Term
+end LambdaCalculus.LocallyNameless.Untyped.Term

--- a/Cslib/Computability/LambdaCalculus/LocallyNameless/Untyped/Properties.lean
+++ b/Cslib/Computability/LambdaCalculus/LocallyNameless/Untyped/Properties.lean
@@ -31,13 +31,13 @@ theorem subst_fresh (x : Var) (t sub : Term Var) (nmem : x ∉ t.fv) : t [x := s
   induction t <;> grind
 
 /- Opening and closing are inverses. -/
-lemma open_close (x : Var) (t : Term Var) (k : ℕ) (nmem : x ∉ t.fv) : t⟦k ↝ fvar x⟧⟦k ↜ x⟧ = t := by
+lemma open_close (x : Var) (t : Term Var) (k : ℕ) (nmem : x ∉ t.fv) : t = t⟦k ↝ fvar x⟧⟦k ↜ x⟧ := by
   induction t generalizing k <;> grind
 
 /-- Opening is injective. -/
 lemma open_injective (x : Var) (M M') (free_M : x ∉ M.fv) (free_M' : x ∉ M'.fv)
     (eq : M ^ fvar x = M' ^ fvar x) : M = M' := by
-  rw [←open_close x M 0 free_M, ←open_close x M' 0 free_M']
+  rw [open_close x M 0 free_M, open_close x M' 0 free_M']
   exact congrArg (closeRec 0 x) eq
 
 /-- Opening and closing are associative for nonclashing free variables. -/
@@ -123,7 +123,7 @@ lemma open_close_to_subst (m : Term Var) (x y : Var) (k : ℕ) (m_lc : LC m) :
     intros k
     have ⟨x', _⟩ := fresh_exists <| free_union (map := fv) Var
     simp only [closeRec_abs, openRec_abs, subst_abs]
-    rw [←open_close x' (t⟦k+1 ↜ x⟧⟦k+1 ↝ fvar y⟧) 0 ?f₁, ←open_close x' (t[x := fvar y]) 0 ?f₂]
+    rw [open_close x' (t⟦k+1 ↜ x⟧⟦k+1 ↝ fvar y⟧) 0 ?f₁, open_close x' (t[x := fvar y]) 0 ?f₂]
     rw [swap_open_fvars, ←swap_open_fvar_close] <;> grind
     case f₁ => grind [open_fresh_preserve_not_fvar, close_preserve_not_fvar]
     case f₂ => grind [subst_preserve_not_fvar]

--- a/Cslib/Computability/LambdaCalculus/LocallyNameless/Untyped/Properties.lean
+++ b/Cslib/Computability/LambdaCalculus/LocallyNameless/Untyped/Properties.lean
@@ -10,45 +10,29 @@ universe u
 
 variable {Var : Type u}
 
-namespace LambdaCalculus.LocallyNameless.Term
+namespace LambdaCalculus.LocallyNameless.Untyped.Term
 
-lemma open_app_inj : app l r = (app l r)⟦i ↝ s⟧ ↔ l = l⟦i ↝ s⟧ ∧ r = r⟦i ↝ s⟧ := by
-  simp [openRec]
-
-lemma open_abs_inj : M.abs = M⟦i + 1 ↝ s⟧.abs ↔ M = M⟦i + 1 ↝ s⟧ := by
-  simp
+attribute [grind =] Finset.union_singleton 
 
 /-- An opening appearing in both sides of an equality of terms can be removed. -/
-lemma open_lc_aux (e : Term Var) : ∀ (j v i u),
-  i ≠ j →
-  e ⟦j ↝ v⟧ = (e ⟦j ↝ v⟧) ⟦i ↝ u⟧ →
-  e = e ⟦i ↝ u⟧ := by
-  induction' e <;> intros j v i u neq h 
-  case app l r ih_l ih_r => 
-    obtain ⟨hl, hr⟩ := open_app_inj.mp h
-    simp only [open_app_inj]
-    exact ⟨ih_l j v i u neq hl, ih_r j v i u neq hr⟩
-  case abs ih =>
-    simp only [openRec_abs, open_abs_inj] at *
-    exact ih (j+1) v (i+1) u (by aesop) h
-  all_goals aesop
+lemma open_lc_aux (e : Term Var) (j v i u) (neq : i ≠ j) (eq : e⟦j ↝ v⟧ = e⟦j ↝ v⟧⟦i ↝ u⟧) : 
+    e = e ⟦i ↝ u⟧ := by
+  induction e generalizing j i <;> grind
 
 /-- Opening is associative for nonclashing free variables. -/
-lemma swap_open_fvars (k n : ℕ) (x y : Var) (m : Term Var) : 
-    k ≠ n → x ≠ y → m⟦n ↝ fvar y⟧⟦k ↝ fvar x⟧ = m⟦k ↝ fvar x⟧⟦n ↝ fvar y⟧ := by
-  revert k n
-  induction' m <;> aesop
+lemma swap_open_fvars (k n : ℕ) (x y : Var) (m : Term Var) (neq : k ≠ n) : 
+    m⟦n ↝ fvar y⟧⟦k ↝ fvar x⟧ = m⟦k ↝ fvar x⟧⟦n ↝ fvar y⟧ := by
+  induction m generalizing k n <;> grind
 
 variable [DecidableEq Var]
 
 /-- Substitution of a free variable not present in a term leaves it unchanged. -/
-theorem subst_fresh (x : Var) (t sub : Term Var) : x ∉ t.fv → (t [x := sub]) = t := by
-  induction t <;> aesop
+theorem subst_fresh (x : Var) (t sub : Term Var) (nmem : x ∉ t.fv) : t [x := sub] = t := by
+  induction t <;> grind
 
 /- Opening and closing are inverses. -/
-lemma open_close (x : Var) (t : Term Var) (k : ℕ) : x ∉ t.fv → t⟦k ↝ fvar x⟧⟦k ↜ x⟧ = t := by
-  revert k
-  induction t <;> aesop
+lemma open_close (x : Var) (t : Term Var) (k : ℕ) (nmem : x ∉ t.fv) : t⟦k ↝ fvar x⟧⟦k ↜ x⟧ = t := by
+  induction t generalizing k <;> grind
 
 /-- Opening is injective. -/
 lemma open_injective (x : Var) (M M') (free_M : x ∉ M.fv) (free_M' : x ∉ M'.fv)
@@ -57,32 +41,28 @@ lemma open_injective (x : Var) (M M') (free_M : x ∉ M.fv) (free_M' : x ∉ M'.
   exact congrArg (closeRec 0 x) eq
 
 /-- Opening and closing are associative for nonclashing free variables. -/
-lemma swap_open_fvar_close (k n : ℕ) (x y : Var) (m : Term Var) : 
-    k ≠ n → x ≠ y → m⟦n ↝ fvar y⟧⟦k ↜ x⟧ = m⟦k ↜ x⟧⟦n ↝ fvar y⟧ := by
-  revert k n
-  induction' m <;> aesop
+lemma swap_open_fvar_close (k n : ℕ) (x y : Var) (m : Term Var) (neq₁ : k ≠ n) (neq₂ : x ≠ y) : 
+    m⟦n ↝ fvar y⟧⟦k ↜ x⟧ = m⟦k ↜ x⟧⟦n ↝ fvar y⟧ := by
+  induction m generalizing k n <;> grind
 
 /-- Closing preserves free variables. -/
-lemma close_preserve_not_fvar {k x y} (m : Term Var) : x ∉ m.fv → x ∉ (m⟦k ↜ y⟧).fv := by
-  revert k
-  induction m <;> aesop
+lemma close_preserve_not_fvar {k x y} (m : Term Var) (nmem : x ∉ m.fv) : x ∉ (m⟦k ↜ y⟧).fv := by
+  induction m generalizing k <;> grind
 
 /-- Opening to a fresh free variable preserves free variables. -/
-lemma open_fresh_preserve_not_fvar {k x y} (m : Term Var) : 
-    x ∉ m.fv → x ≠ y → x ∉ (m⟦k ↝ fvar y⟧).fv := by
-  revert k
-  induction m <;> aesop
+lemma open_fresh_preserve_not_fvar {k x y} (m : Term Var) (nmem : x ∉ m.fv) (neq : x ≠ y) :
+    x ∉ (m⟦k ↝ fvar y⟧).fv := by
+  induction m generalizing k <;> grind
 
 /-- Substitution preserves free variables. -/
-lemma subst_preserve_not_fvar {x y : Var} (m n : Term Var) : 
-    x ∉ m.fv ∪ n.fv → x ∉ (m [y := n]).fv := by
-  induction m
-  all_goals aesop
+lemma subst_preserve_not_fvar {x y : Var} (m n : Term Var) (nmem : x ∉ m.fv ∪ n.fv) : 
+    x ∉ (m [y := n]).fv := by
+  induction m <;> grind
 
 /-- Closing removes a free variable. -/
+@[scoped grind ←]
 lemma close_var_not_fvar_rec (x) (k) (t : Term Var) : x ∉ (t⟦k ↜ x⟧).fv := by
-  revert k
-  induction t <;> aesop
+  induction t generalizing k <;> grind
 
 /-- Specializes `close_var_not_fvar_rec` to first closing. -/
 lemma close_var_not_fvar (x) (t : Term Var) : x ∉ (t ^* x).fv := close_var_not_fvar_rec x 0 t
@@ -91,58 +71,50 @@ variable [HasFresh Var]
 
 omit [DecidableEq Var] in
 /-- A locally closed term is unchanged by opening. -/
-@[aesop safe (rule_sets := [LambdaCalculus.LocallyNameless.ruleSet])]
-lemma open_lc (k t) (e : Term Var) : e.LC → e = e⟦k ↝ t⟧ := by
-  intros e_lc
-  revert k
-  induction e_lc
+@[scoped grind =_]
+lemma open_lc (k t) (e : Term Var) (e_lc : e.LC) : e = e⟦k ↝ t⟧ := by
+  induction e_lc generalizing k
   case abs xs e _ ih => 
-    intros k
     simp only [openRec_abs, abs.injEq]
-    refine open_lc_aux e 0 (fvar (fresh xs)) (k+1) t ?_ ?_ <;> aesop
-  all_goals aesop
+    apply open_lc_aux e 0 (fvar (fresh xs)) (k+1) t <;> grind
+  all_goals grind
 
 /-- Substitution of a locally closed term distributes with opening. -/
-lemma subst_open (x : Var) (t : Term Var) (k : ℕ) (u e) :
-  LC t → 
-  (e ⟦ k ↝ u ⟧) [ x := t ] = (e [ x := t ]) ⟦k ↝  u [ x := t ]⟧ := by
-  revert k
-  induction' e <;> aesop
+@[scoped grind]
+lemma subst_openRec (x : Var) (t : Term Var) (k : ℕ) (u e) (lc : LC t) : 
+    (e⟦ k ↝ u ⟧)[x := t] = e[x := t]⟦k ↝  u [ x := t ]⟧ := by
+  induction e generalizing k <;> grind
 
-/-- Specialize `subst_open` to the first opening. -/
+/-- Specialize `subst_openRec` to the first opening. -/
+lemma subst_open (x : Var) (t : Term Var) (u e) (lc : LC t) : 
+    (e ^ u)[x := t] = e[x := t] ^ u [ x := t ] := by grind
+
+/-- Specialize `subst_open` to the free variables. -/
 theorem subst_open_var (x y : Var) (u e : Term Var) (neq : y ≠ x) (u_lc : LC u) : 
-    (e [y := u]) ^ fvar x = (e ^ fvar x) [y := u] := by
-  have h : (e ^ fvar x)[y:=u] = e[y:=u] ^ (fvar x)[y:=u] := subst_open y u 0 (fvar x) e u_lc
-  aesop
+    (e ^ fvar x)[y := u] = e[y := u] ^ fvar x := by grind
 
 /-- Substitution of locally closed terms is locally closed. -/
-theorem subst_lc {x : Var} {e u : Term Var} : LC e → LC u → LC (e [x := u]) := by
-  intros lc_e lc_u
-  induction lc_e 
-  case abs xs e _ ih =>
-    refine LC.abs ({x} ∪ xs) _ (?_ : ∀ y ∉ {x} ∪ xs, (e[x := u] ^ fvar y).LC)
-    intros y mem
-    rw [subst_open_var y x u e ?_ lc_u]
-    all_goals aesop
-  all_goals aesop
+@[scoped grind]
+theorem subst_lc {x : Var} {e u : Term Var} (e_lc : LC e) (u_lc : LC u) : LC (e [x := u]) := by
+  induction e_lc
+  case' abs => apply LC.abs (free_union Var)
+  all_goals grind
 
 /-- Opening to a term `t` is equivalent to opening to a free variable and substituting for `t`. -/
+@[scoped grind]
 lemma subst_intro (x : Var) (t e : Term Var) (mem : x ∉ e.fv) (t_lc : LC t) : 
-    e ^ t = (e ^ fvar x) [ x := t ] := by
-  simp only [open']
-  rw [subst_open x t 0 (fvar x) e t_lc, subst_fresh _ _ t mem]
-  aesop
+    e ^ t = (e ^ fvar x) [ x := t ] := by grind [subst_fresh]
 
 /-- Opening of locally closed terms is locally closed. -/
-theorem beta_lc {M N : Term Var} (m_lc : M.abs.LC) : LC N → LC (M ^ N) := by
+@[scoped grind ←]
+theorem beta_lc {M N : Term Var} (m_lc : M.abs.LC) (n_lc : LC N) : LC (M ^ N) := by
   cases m_lc
   case abs xs mem =>
-    intros n_lc
     have ⟨y, _⟩ := fresh_exists <| free_union (map := fv) Var
-    rw [subst_intro y N M (by aesop) (by assumption)]
-    apply subst_lc <;> aesop
+    grind
 
 /-- Opening then closing is equivalent to substitution. -/
+@[scoped grind =]
 lemma open_close_to_subst (m : Term Var) (x y : Var) (k : ℕ) (m_lc : LC m) : 
     m ⟦k ↜ x⟧⟦k ↝ fvar y⟧ = m [x := fvar y] := by
   revert k
@@ -150,31 +122,23 @@ lemma open_close_to_subst (m : Term Var) (x y : Var) (k : ℕ) (m_lc : LC m) :
   case abs xs t x_mem ih =>
     intros k
     have ⟨x', _⟩ := fresh_exists <| free_union (map := fv) Var
-    have s := subst_open_var x' x (fvar y) t (by aesop) (by constructor)
     simp only [closeRec_abs, openRec_abs, subst_abs]
-    simp only [open'] at *
     rw [←open_close x' (t⟦k+1 ↜ x⟧⟦k+1 ↝ fvar y⟧) 0 ?f₁, ←open_close x' (t[x := fvar y]) 0 ?f₂]
-    rw [swap_open_fvars, ←swap_open_fvar_close, s, ih] <;> aesop
-    case f₁ => refine open_fresh_preserve_not_fvar _ (close_preserve_not_fvar _ ?_) ?_ <;> aesop
-    case f₂ => apply subst_preserve_not_fvar; aesop
-  all_goals aesop
+    rw [swap_open_fvars, ←swap_open_fvar_close] <;> grind
+    case f₁ => grind [open_fresh_preserve_not_fvar, close_preserve_not_fvar]
+    case f₂ => grind [subst_preserve_not_fvar]
+  all_goals grind
 
 /-- Closing and opening are inverses. -/
-lemma close_open (x : Var) (t : Term Var) (k : ℕ) : LC t → t⟦k ↜ x⟧⟦k ↝ fvar x⟧ = t := by
-  intros lc_t
-  revert k
-  induction lc_t
+lemma close_open (x : Var) (t : Term Var) (k : ℕ) (t_lc : LC t) : t⟦k ↜ x⟧⟦k ↝ fvar x⟧ = t := by
+  induction t_lc generalizing k
   case abs xs t t_open_lc ih => 
-    intros k
     simp only [closeRec_abs, openRec_abs, abs.injEq]
     let z := t⟦k + 1 ↜ x⟧⟦k + 1 ↝ fvar x⟧
     have ⟨y, _⟩ := fresh_exists <| free_union (map := fv) Var
-    refine open_injective y _ _ (by aesop) (by aesop) ?_
-    rw [←ih y ?_ (k+1)]
-    · simp only [open']
-      rw [swap_open_fvar_close, swap_open_fvars]
-      all_goals aesop
-    aesop
-  all_goals aesop
+    refine open_injective y _ _ ?_ ?_ ?f
+    case f => rw [←ih y ?_ (k+1)] <;> grind [swap_open_fvar_close, swap_open_fvars]
+    all_goals grind
+  all_goals grind
 
-end LambdaCalculus.LocallyNameless.Term
+end LambdaCalculus.LocallyNameless.Untyped.Term

--- a/Cslib/Data/HasFresh.lean
+++ b/Cslib/Data/HasFresh.lean
@@ -23,7 +23,7 @@ class HasFresh (α : Type u) where
   /-- Proof that `fresh` returns a fresh element for its input set. -/
   fresh_notMem (s : Finset α) : fresh s ∉ s
 
-attribute [simp] HasFresh.fresh_notMem
+attribute [grind <=] HasFresh.fresh_notMem
 
 /-- An existential version of the `HasFresh` typeclass. This is useful for the sake of brevity
 in proofs. -/


### PR DESCRIPTION
This PR migrates all uses of `aesop` to `grind` for locally nameless lambda calculi. This works very well, with some proofs being drastically simplified, better scoping, and working with a core Lean feature. This would close #18 as obsolete.

The one small regression is not being able to automatically register patterns with cofinite quantification. I have asked on Zulip if a custom `grind_pattern` would work here. However, it is very rare that aesop successfully used this feature either. By my count there was one singular proof that would be simpler because of this. I have left a comment there.

While I was here, I made some other minor improvements:
- adopted the Mathlib style of named hypotheses
- fixed some namespace inconsistencies
- fixed some confusing API in `LocallyNameless.Untyped.Properties`