### PR TITLE
add type paramater to HasSubstitution

### DIFF
--- a/Cslib/Computability/LambdaCalculus/LocallyNameless/Untyped/Basic.lean
+++ b/Cslib/Computability/LambdaCalculus/LocallyNameless/Untyped/Basic.lean
@@ -90,7 +90,7 @@ def subst (m : Term Var) (x : Var) (sub : Term Var) : Term Var :=
   | abs M   => abs <| M.subst x sub
 
 /-- `Term.subst` is a substitution for λ-terms. Gives access to the notation `m[x := n]`. -/
-instance instHasSubstitutionTerm : HasSubstitution (Term Var) Var where
+instance instHasSubstitutionTerm : HasSubstitution (Term Var) Var (Term Var) where
   subst := Term.subst
 
 /-- Free variables of a term. -/
@@ -124,7 +124,9 @@ lemma closeRec_app : (app l r)⟦k ↜ x⟧ = app (l⟦k ↜ x⟧) (r⟦k ↜ x�
 
 lemma closeRec_abs : t.abs⟦k ↜ x⟧ = t⟦k + 1 ↜ x⟧.abs := by rfl
 
-lemma subst_bvar {n : Term Var} : (bvar i)[x := n] = bvar i := by rfl
+variable {x : Var} {n : Term Var}
+
+lemma subst_bvar : (bvar i : Term Var)[x := n] = bvar i := by rfl
 
 lemma subst_fvar : (fvar x')[x := n] = if x = x' then n else fvar x' := by rfl
 

--- a/Cslib/Computability/LambdaCalculus/LocallyNameless/Untyped/Properties.lean
+++ b/Cslib/Computability/LambdaCalculus/LocallyNameless/Untyped/Properties.lean
@@ -81,12 +81,12 @@ lemma open_lc (k t) (e : Term Var) (e_lc : e.LC) : e = e⟦k ↝ t⟧ := by
 
 /-- Substitution of a locally closed term distributes with opening. -/
 @[scoped grind]
-lemma subst_openRec (x : Var) (t : Term Var) (k : ℕ) (u e) (lc : LC t) : 
+lemma subst_openRec (x : Var) (t : Term Var) (k : ℕ) (u e : Term Var) (lc : LC t) : 
     (e⟦ k ↝ u ⟧)[x := t] = e[x := t]⟦k ↝  u [ x := t ]⟧ := by
   induction e generalizing k <;> grind
 
 /-- Specialize `subst_openRec` to the first opening. -/
-lemma subst_open (x : Var) (t : Term Var) (u e) (lc : LC t) : 
+lemma subst_open (x : Var) (t : Term Var) (u e : Term Var) (lc : LC t) : 
     (e ^ u)[x := t] = e[x := t] ^ u [ x := t ] := by grind
 
 /-- Specialize `subst_open` to the free variables. -/

--- a/Cslib/Computability/LambdaCalculus/Named/Untyped/Basic.lean
+++ b/Cslib/Computability/LambdaCalculus/Named/Untyped/Basic.lean
@@ -94,7 +94,7 @@ decreasing_by all_goals grind [rename.eq_sizeOf, abs.sizeOf_spec, app.sizeOf_spe
 
 /-- `Term.subst` is a substitution for λ-terms. Gives access to the notation `m[x := n]`. -/
 instance instHasSubstitutionTerm [DecidableEq Var] [HasFresh Var] :
-    HasSubstitution (Term Var) Var where
+    HasSubstitution (Term Var) Var (Term Var) where
   subst := Term.subst
 
 -- TODO

--- a/Cslib/Syntax/HasSubstitution.lean
+++ b/Cslib/Syntax/HasSubstitution.lean
@@ -5,9 +5,9 @@ Authors: Fabrizio Montesi
 -/
 
 /-- Typeclass for substitution relations and access to their notation. -/
-class HasSubstitution (α : Type u) (β : Type v) where
+class HasSubstitution (α : Type u) (β : Type v) (γ : Type w) where
   /-- Substitution function. Replaces `x` in `t` with `t'`. -/
-  subst (t : α) (x : β) (t' : α) : α
+  subst (t : α) (x : β) (t' : γ) : α
 
 /-- Notation for substitution. -/
 notation t:max "[" x ":=" t' "]" => HasSubstitution.subst t x t'


### PR DESCRIPTION
Currently the `HasSubstitution` notation typeclass assumes that what is being substituted and what it is being substituted within have the same type. This is inconvenient in some cases, for instance polymorphism where we have multiple notations of substitution on types and terms.

(I am separating a couple of PRs from my work on System F to try to make the reviews go a little easier)