### PR TITLE
Allow multiple maps in `free_union`

### DIFF
--- a/Cslib/Computability/LambdaCalculus/LocallyNameless/Stlc/Basic.lean
+++ b/Cslib/Computability/LambdaCalculus/LocallyNameless/Stlc/Basic.lean
@@ -122,7 +122,7 @@ lemma subst_aux (h : Δ ++ ⟨x, σ⟩ :: Γ ⊢ t ∶ τ) (der : Γ ⊢ s ∶ �
       refine (weaken der ?_).perm perm
       exact Context.wf_perm (id (List.Perm.symm perm)) ok_weak
   case abs σ Γ' t T2 xs ih' ih =>
-    apply Typing.abs (xs ∪ {x} ∪ (Δ ++ Γ).dom)
+    apply Typing.abs (free_union Var)
     intros
     rw [subst_def, ←subst_open_var _ _ _ _ ?_ der.lc] <;> grind
 
@@ -136,7 +136,7 @@ lemma typing_subst_head (weak : ⟨x, σ⟩ :: Γ ⊢ t ∶ τ) (der : Γ ⊢ s 
 theorem preservation_open {xs : Finset Var}
   (cofin : ∀ x ∉ xs, ⟨x, σ⟩ :: Γ ⊢ m ^ fvar x ∶ τ) (der : Γ ⊢ n ∶ σ) : 
     Γ ⊢ m ^ n ∶ τ := by
-  have ⟨fresh, _⟩ := fresh_exists <| free_union (map := Term.fv) Var
+  have ⟨fresh, _⟩ := fresh_exists <| free_union [Term.fv] Var
   rw [subst_intro fresh n m (by grind) der.lc]
   exact typing_subst_head (by grind) der
 

--- a/Cslib/Computability/LambdaCalculus/LocallyNameless/Untyped/FullBeta.lean
+++ b/Cslib/Computability/LambdaCalculus/LocallyNameless/Untyped/FullBeta.lean
@@ -106,7 +106,7 @@ lemma redex_abs_close {x : Var} (step : M ↠βᶠ M') : (M⟦0 ↜ x⟧.abs ↠
 /-- Multiple reduction of opening implies multiple reduction of abstraction. -/
 theorem redex_abs_cong (xs : Finset Var) (cofin : ∀ x ∉ xs, (M ^ fvar x) ↠βᶠ (M' ^ fvar x)) : 
     M.abs ↠βᶠ M'.abs := by
-  have ⟨fresh, _⟩ := fresh_exists <| free_union (map := fv) Var
+  have ⟨fresh, _⟩ := fresh_exists <| free_union [fv] Var
   rw [open_close fresh M 0 ?_, open_close fresh M' 0 ?_]
   all_goals grind [redex_abs_close]
 

--- a/Cslib/Computability/LambdaCalculus/LocallyNameless/Untyped/FullBetaConfluence.lean
+++ b/Cslib/Computability/LambdaCalculus/LocallyNameless/Untyped/FullBetaConfluence.lean
@@ -125,7 +125,7 @@ lemma para_open_close (x y z) (para : M ⭢ₚ M') (_ : y ∉ M.fv ∪ M'.fv ∪
 /-- Parallel substitution respects fresh opening. -/
 lemma para_open_out (L : Finset Var) (mem : ∀ x, x ∉ L → (M ^ fvar x) ⭢ₚ N ^ fvar x)
     (para : M' ⭢ₚ N') : (M ^ M') ⭢ₚ (N ^ N') := by
-  let ⟨x, _⟩ := fresh_exists <| free_union (map := fv) Var
+  let ⟨x, _⟩ := fresh_exists <| free_union [fv] Var
   grind
 
 -- TODO: the Takahashi translation would be a much nicer and shorter proof, but I had difficultly
@@ -141,20 +141,20 @@ theorem para_diamond : Diamond (@Parallel Var) := by
   case abs s1 s2' xs mem ih => 
     cases tpt2
     case abs t2' xs' mem' =>
-      have ⟨x, qx⟩ := fresh_exists (xs ∪ xs' ∪ free_union (map := fv) Var)
+      have ⟨x, qx⟩ := fresh_exists (xs ∪ xs' ∪ free_union [fv] Var)
       simp only [Finset.union_assoc, Finset.mem_union, not_or] at qx
       have ⟨q1, q2, _⟩ := qx
       have ⟨t', _⟩ := ih x q1 (mem' _ q2)
       exists abs (t' ^* x)
       constructor 
       <;> [let z := s2' ^ fvar x; let z := t2' ^ fvar x]
-      <;> apply Parallel.abs (free_union (map := fv) Var) <;> grind
+      <;> apply Parallel.abs (free_union [fv] Var) <;> grind
   case beta s1 s1' s2 s2' xs mem ps ih1 ih2 => 
     cases tpt2
     case app u2 u2' s1pu2 s2pu2' => 
       cases s1pu2
       case abs s1'' xs' mem' =>
-        have ⟨x, qx⟩ := fresh_exists (xs ∪ xs' ∪ free_union (map := fv) Var)
+        have ⟨x, qx⟩ := fresh_exists (xs ∪ xs' ∪ free_union [fv] Var)
         simp only [Finset.union_assoc, Finset.mem_union, not_or] at qx
         obtain ⟨q1, q2, _⟩ := qx
         have ⟨t', _⟩ := ih2 s2pu2'
@@ -162,9 +162,9 @@ theorem para_diamond : Diamond (@Parallel Var) := by
         exists (t'' ^* x) ^ t'
         constructor
         · grind
-        · apply Parallel.beta (free_union (map := fv) Var) <;> grind
+        · apply Parallel.beta (free_union [fv] Var) <;> grind
     case beta u1' u2' xs' mem' s2pu2' => 
-      have ⟨x, qx⟩ := fresh_exists (xs ∪ xs' ∪ free_union (map := fv) Var)
+      have ⟨x, qx⟩ := fresh_exists (xs ∪ xs' ∪ free_union [fv] Var)
       simp only [Finset.union_assoc, Finset.mem_union, not_or] at qx
       have ⟨q1, q2, _⟩ := qx
       have ⟨t', _⟩ := ih2 s2pu2'
@@ -180,7 +180,7 @@ theorem para_diamond : Diamond (@Parallel Var) := by
     case beta t1' u1' u2' xs mem s2pu2' => 
       cases s1ps1'
       case abs s1'' xs' mem' =>
-        have ⟨x, qx⟩ := fresh_exists (xs ∪ xs' ∪ free_union (map := fv) Var)
+        have ⟨x, qx⟩ := fresh_exists (xs ∪ xs' ∪ free_union [fv] Var)
         simp only [Finset.union_assoc, Finset.mem_union, not_or] at qx
         obtain ⟨q1, q2, _⟩ := qx
         have ⟨t', qt'_l, qt'_r⟩ := ih2 s2pu2'

--- a/Cslib/Computability/LambdaCalculus/LocallyNameless/Untyped/Properties.lean
+++ b/Cslib/Computability/LambdaCalculus/LocallyNameless/Untyped/Properties.lean
@@ -81,12 +81,12 @@ lemma open_lc (k t) (e : Term Var) (e_lc : e.LC) : e = e⟦k ↝ t⟧ := by
 
 /-- Substitution of a locally closed term distributes with opening. -/
 @[scoped grind]
-lemma subst_openRec (x : Var) (t : Term Var) (k : ℕ) (u e) (lc : LC t) : 
+lemma subst_openRec (x : Var) (t : Term Var) (k : ℕ) (u e : Term Var) (lc : LC t) : 
     (e⟦ k ↝ u ⟧)[x := t] = e[x := t]⟦k ↝  u [ x := t ]⟧ := by
   induction e generalizing k <;> grind
 
 /-- Specialize `subst_openRec` to the first opening. -/
-lemma subst_open (x : Var) (t : Term Var) (u e) (lc : LC t) : 
+lemma subst_open (x : Var) (t : Term Var) (u e : Term Var) (lc : LC t) : 
     (e ^ u)[x := t] = e[x := t] ^ u [ x := t ] := by grind
 
 /-- Specialize `subst_open` to the free variables. -/
@@ -110,7 +110,7 @@ lemma subst_intro (x : Var) (t e : Term Var) (mem : x ∉ e.fv) (t_lc : LC t) :
 theorem beta_lc {M N : Term Var} (m_lc : M.abs.LC) (n_lc : LC N) : LC (M ^ N) := by
   cases m_lc
   case abs xs mem =>
-    have ⟨y, _⟩ := fresh_exists <| free_union (map := fv) Var
+    have ⟨y, _⟩ := fresh_exists <| free_union [fv] Var
     grind
 
 /-- Opening then closing is equivalent to substitution. -/
@@ -121,7 +121,7 @@ lemma open_close_to_subst (m : Term Var) (x y : Var) (k : ℕ) (m_lc : LC m) :
   induction' m_lc 
   case abs xs t x_mem ih =>
     intros k
-    have ⟨x', _⟩ := fresh_exists <| free_union (map := fv) Var
+    have ⟨x', _⟩ := fresh_exists <| free_union [fv] Var
     simp only [closeRec_abs, openRec_abs, subst_abs]
     rw [open_close x' (t⟦k+1 ↜ x⟧⟦k+1 ↝ fvar y⟧) 0 ?f₁, open_close x' (t[x := fvar y]) 0 ?f₂]
     rw [swap_open_fvars, ←swap_open_fvar_close] <;> grind
@@ -135,7 +135,7 @@ lemma close_open (x : Var) (t : Term Var) (k : ℕ) (t_lc : LC t) : t⟦k ↜ x�
   case abs xs t t_open_lc ih => 
     simp only [closeRec_abs, openRec_abs, abs.injEq]
     let z := t⟦k + 1 ↜ x⟧⟦k + 1 ↝ fvar x⟧
-    have ⟨y, _⟩ := fresh_exists <| free_union (map := fv) Var
+    have ⟨y, _⟩ := fresh_exists <| free_union [fv] Var
     refine open_injective y _ _ ?_ ?_ ?f
     case f => rw [←ih y ?_ (k+1)] <;> grind [swap_open_fvar_close, swap_open_fvars]
     all_goals grind

--- a/Cslib/Data/HasFresh.lean
+++ b/Cslib/Data/HasFresh.lean
@@ -32,10 +32,14 @@ theorem HasFresh.fresh_exists {α : Type u} [HasFresh α] (s : Finset α) : ∃ 
 
 open Lean Elab Term Meta Parser Tactic
 
+/-- Configuration for the `free_union` term elaborator. -/
 structure FreeUnionConfig where
+  /-- For `free_union Var`, include all `x : Var`. Defaults to true. -/
   singleton : Bool := true
+  /-- For `free_union Var`, include all `xs : Finset Var`. Defaults to true. -/
   finset : Bool := true
 
+/-- Elaborate a FreeUnionConfig. -/
 declare_config_elab elabFreeUnionConfig FreeUnionConfig
 
 /-- 
@@ -70,6 +74,7 @@ declare_config_elab elabFreeUnionConfig FreeUnionConfig
 -/
 syntax (name := freeUnion) "free_union" optConfig (" [" (term,*) "]")? term : term
 
+/-- Elaborator for `free_union`. -/
 @[term_elab freeUnion]
 def HasFresh.freeUnion : TermElab := fun stx _ => do
   match stx with

--- a/Cslib/Data/HasFresh.lean
+++ b/Cslib/Data/HasFresh.lean
@@ -30,85 +30,95 @@ in proofs. -/
 theorem HasFresh.fresh_exists {α : Type u} [HasFresh α] (s : Finset α) : ∃ a, a ∉ s :=
   ⟨fresh s, fresh_notMem s⟩
 
-open Lean Elab Term Meta Parser Tactic in
+open Lean Elab Term Meta Parser Tactic
+
+structure FreeUnionConfig where
+  singleton : Bool := true
+  finset : Bool := true
+
+declare_config_elab elabFreeUnionConfig FreeUnionConfig
+
 /-- 
-  Given a `DecidableEq Var` instance, this elaborator automatically constructs the union of any
-  variables, finite sets of variables, and optionally the results of a provided function mapping to
-  variables.
+  Given a `DecidableEq Var` instance, this elaborator automatically constructs
+  the union of any variables, finite sets of variables, and optionally the
+  results of provided functions mapping to variables. This is configurable with
+  optional boolean boolean arguments `singleton` and `finset`.
 
   As an example, consider the following:
 
   ```
-  variable {Var Term : Type} [DecidableEq Var]
+  variable (x : ℕ) (xs : Finset ℕ) (var : String)
   
-  example (x : Var) (xs : Finset Var) : True := by
-    -- free : Finset Var := ∅ ∪ {x} ∪ xs
-    let free := free_union Var
-    trivial
+  def f (_ : String) : Finset ℕ := {1, 2, 3}
+  def g (_ : String) : Finset ℕ := {4, 5, 6}
   
-  example (x : Var) (xs : Finset Var) (t : Term) (fv : Term → Finset Var) : True := by
-    -- free : Finset Var := ∅ ∪ {x} ∪ xs ∪ fv t
-    let free := free_union (map := fv) Var
-    trivial
+  -- info: ∅ ∪ {x} ∪ id xs : Finset ℕ
+  #check free_union ℕ
+  
+  -- info: ∅ ∪ {x} ∪ id xs ∪ f var ∪ g var : Finset ℕ
+  #check free_union [f, g] ℕ
+  
+  info: ∅ ∪ id xs : Finset ℕ
+  #check free_union (singleton := false) ℕ
+  
+  -- info: ∅ ∪ {x} : Finset ℕ
+  #check free_union (finset := false) ℕ
+  
+  -- info: ∅ : Finset ℕ
+  #check free_union (singleton := false) (finset := false) ℕ
   ```
 -/
-elab "free_union" cfg:optConfig var:term : term => do
-  -- the type of our variables
-  let var ← elabType var
+syntax (name := freeUnion) "free_union" optConfig (" [" (term,*) "]")? term : term
 
-  -- handle the optional map calculation
-   let map ← 
-     match cfg with
-     | `(optConfig| (map := $map:term)) => elabTerm map none
-     | _ => mkConst ``Empty
+@[term_elab freeUnion]
+def HasFresh.freeUnion : TermElab := fun stx _ => do
+  match stx with
+  | `(free_union $cfg $[[$maps,*]]? $var:term) =>
+    let cfg ← elabFreeUnionConfig cfg |>.run { elaborator := .anonymous } |>.run' { goals := [] }
 
-  let map_ty ← inferType map
+    -- the type of our variables
+    let var ← elabType var
 
-  let map_dom := 
-    match map_ty with
-    | Expr.forallE _ dom _ _ => dom
-    | _ => mkConst ``Empty
+    -- maps to variables
+    let maps := maps.map (·.getElems) |>.getD #[]
+    let mut maps ← maps.mapM (flip elabTerm none)
 
-  let mut finsets := #[]
+    -- construct ∅
+    let dl ← getDecLevel var
+    let FinsetType := mkApp (mkConst ``Finset [dl]) var
+    let EmptyCollectionInst ← synthInstance (mkApp (mkConst ``EmptyCollection [dl]) FinsetType)
+    let empty := 
+      mkAppN (mkConst ``EmptyCollection.emptyCollection [dl]) #[FinsetType, EmptyCollectionInst]
 
-  -- construct ∅
-  let dl ← getDecLevel var
-  let FinsetType := mkApp (mkConst ``Finset [dl]) var
-  let EmptyCollectionInst ← synthInstance (mkApp (mkConst ``EmptyCollection [dl]) FinsetType)
-  let empty := 
-    mkAppN (mkConst ``EmptyCollection.emptyCollection [dl]) #[FinsetType, EmptyCollectionInst]
+    -- singleton variables
+    if cfg.singleton then
+      let SingletonInst ← synthInstance <| mkAppN (mkConst ``Singleton [dl, dl]) #[var, FinsetType]
+      let singleton_map := 
+        mkAppN (mkConst ``Singleton.singleton [dl, dl]) #[var, FinsetType, SingletonInst]
+      maps := maps.push singleton_map
 
-  let SingletonInst ← synthInstance <| mkAppN (mkConst ``Singleton [dl, dl]) #[var, FinsetType]
+    -- any finite sets
+    if cfg.finset then
+      let id_map := mkApp (mkConst ``id [← getLevel var]) FinsetType
+      maps := maps.push id_map
 
-  for ldecl in (← getLCtx) do
-    if !ldecl.isImplementationDetail then
-      let local_type ← inferType (mkFVar ldecl.fvarId)
+    let mut finsets := #[]
 
-      -- any finite sets
-      if let  (``Finset, #[var']) := local_type.getAppFnArgs then
-        if (← isDefEq var var') then 
-          finsets := finsets.push ldecl.toExpr
-      else
-      -- singleton variables
-      if (← isDefEq local_type var) then
-        let singleton := 
-          mkAppN 
-          (mkConst ``Singleton.singleton [dl, dl]) 
-          #[var, FinsetType, SingletonInst, ldecl.toExpr]
-        finsets := finsets.push singleton
-      else
-      -- map to variables
-      if (←isDefEq local_type map_dom) then
-        finsets := finsets.push (mkApp map ldecl.toExpr)
-      else
-        pure ()
+    for ldecl in (← getLCtx) do
+      if !ldecl.isImplementationDetail then
+        let local_type ← ldecl.toExpr |> inferType >=> whnf
+        for map in maps do
+          if let Expr.forallE _ dom _ _ := ← inferType map then
+            if (←isDefEq local_type dom) then
+              finsets := finsets.push (mkApp map ldecl.toExpr)
 
-  -- construct a union fold
-  let UnionInst ← synthInstance (mkApp (mkConst ``Union [dl]) FinsetType)
-  let UnionFinset := mkAppN (mkConst `Union.union [dl]) #[FinsetType, UnionInst]
-  let union := finsets.foldl (mkApp2 UnionFinset) empty
-    
-  return union
+    -- construct a union fold
+    let UnionInst ← synthInstance (mkApp (mkConst ``Union [dl]) FinsetType)
+    let UnionFinset := mkAppN (mkConst ``Union.union [dl]) #[FinsetType, UnionInst]
+    let union := finsets.foldl (mkApp2 UnionFinset) empty
+      
+    return union
+  | _ => throwUnsupportedSyntax
 
 export HasFresh (fresh fresh_notMem fresh_exists)
 

--- a/CslibTests/HasFresh.lean
+++ b/CslibTests/HasFresh.lean
@@ -14,8 +14,38 @@ example (x : Var) (xs : Finset Var) : ∃ y, x ≠ y ∧ y ∉ xs := by
 def fv : Term → Finset ℕ := fun _ ↦ {1, 2, 3}
 
 /-- An example including a specified `free` function. -/
-example (t : Term) (x : ℕ) (xs : Finset ℕ) : 
+example (_ : Term) (x : ℕ) (xs : Finset ℕ) : 
     ∃ y : ℕ, x ≠ y ∧ y ∉ xs ∧ y ∉ ({1, 2, 3} : Finset ℕ) := by
-  let ⟨fresh, _⟩ := fresh_exists <| free_union (map := @fv Term) ℕ
+  let ⟨fresh, _⟩ := fresh_exists <| free_union [@fv Term] ℕ
   exists fresh
   aesop
+
+-- check that options work as expected
+section
+
+variable (x : ℕ) (xs : Finset ℕ) (var : String)
+
+def f (_ : String) : Finset ℕ := {1, 2, 3}
+def g (_ : String) : Finset ℕ := {4, 5, 6}
+
+/-- info: ∅ ∪ {x} ∪ id xs : Finset ℕ -/
+#guard_msgs in
+#check free_union ℕ
+
+/-- info: ∅ ∪ {x} ∪ id xs ∪ f var ∪ g var : Finset ℕ -/
+#guard_msgs in
+#check free_union [f, g] ℕ
+
+/-- info: ∅ ∪ id xs : Finset ℕ -/
+#guard_msgs in
+#check free_union (singleton := false) ℕ
+
+/-- info: ∅ ∪ {x} : Finset ℕ -/
+#guard_msgs in
+#check free_union (finset := false) ℕ
+
+/-- info: ∅ : Finset ℕ -/
+#guard_msgs in
+#check free_union (singleton := false) (finset := false) ℕ
+
+end


### PR DESCRIPTION
This closes #44. As I suspected, it also simplifies the implementation, as singleton variables and finsets in the local context are just special cases. I also like your suggested syntax better.

You can't really see it at work here much yet (besides the testing) but this is very useful for polymorphism, where you can now concisely select a variable that is free from any type or term variables.