### PR TITLE
fix: `LambdaCalculus.Named.Term.subst` scoping problem

### DIFF
--- a/Cslib/Computability/LambdaCalculus/Named/Untyped/Basic.lean
+++ b/Cslib/Computability/LambdaCalculus/Named/Untyped/Basic.lean
@@ -86,7 +86,7 @@ def Term.subst [DecidableEq Var] [HasFresh Var] (m : Term Var) (x : Var) (r : Te
     else if y ∉ r.fv then
       abs y (m'.subst x r)
     else
-      let z := HasFresh.fresh (abs y m').vars
+      let z := HasFresh.fresh (m'.vars ∪ r.vars ∪ {x})
       abs z ((m'.rename y z).subst x r)
   | app m1 m2 => app (m1.subst x r) (m2.subst x r)
 termination_by m

--- a/CslibTests/LambdaCalculus.lean
+++ b/CslibTests/LambdaCalculus.lean
@@ -17,4 +17,8 @@ example : (abs 0 (var 0)) =α (abs 1 (var 1)) := by
   constructor
   simp [Term.fv]
 
+example : (abs 1 (var 0)).subst 0 (app (var 1) (var 2)) = (abs 3 (app (var 1) (var 2))) := by
+  simp [Term.subst, Term.fv, Term.bv, Term.vars, Term.rename]
+  apply rfl
+
 -- example : (abs 0 (abs 1 (app (var 0) (var 1)))) =α (abs 1 (abs 0 (app (var 1) (var 0)))) := by

--- a/CslibTests/LambdaCalculus.lean
+++ b/CslibTests/LambdaCalculus.lean
@@ -18,7 +18,19 @@ example : (abs 0 (var 0)) =α (abs 1 (var 1)) := by
   simp [Term.fv]
 
 example : (abs 1 (var 0)).subst 0 (app (var 1) (var 2)) = (abs 3 (app (var 1) (var 2))) := by
-  simp [Term.subst, Term.fv, Term.bv, Term.vars, Term.rename]
-  apply rfl
+  simp [subst, fv, bv, vars, rename, instHasFreshNat, HasFresh.ofSucc]
+
+def x := 0
+def y := 1
+def z := 2
+def w := 3
+
+attribute [simp] x y z w
+
+local instance coeNatTerm : Coe ℕ (Term ℕ) := ⟨Term.var⟩
+
+-- section 5.3.4 of TAPL
+example : (abs y (app x y))[x := (app y z : Term ℕ)] = (abs w (app (app y z) w)) := by 
+  simp [subst, fv, bv, vars, rename, instHasFreshNat, HasFresh.ofSucc, instHasSubstitutionTerm]
 
 -- example : (abs 0 (abs 1 (app (var 0) (var 1)))) =α (abs 1 (abs 0 (app (var 1) (var 0)))) := by


### PR DESCRIPTION
## Counterexamples

Old:

```lean
def t : Term ℕ := .abs 1 (.var 0)
#eval t.subst 0 (.app (.app (.var 1) (.var 2)) (.var 3)) -- abs 2 (app (app 1 2) 3)
```

New:

```lean
def t : Term ℕ := .abs 1 (.var 0)
#eval t.subst 0 (.app (.app (.var 1) (.var 2)) (.var 3)) -- abs 4 (app (app 1 2) 3)
```