### PR TITLE
Rice's theorem

### DIFF
--- a/Cslib/Computability/CombinatoryLogic/Basic.lean
+++ b/Cslib/Computability/CombinatoryLogic/Basic.lean
@@ -61,7 +61,7 @@ def Polynomial.eval {n : Nat} (Γ : SKI.Polynomial n) (l : List SKI) (hl : List.
 def Polynomial.varFreeToSKI (Γ : SKI.Polynomial 0) : SKI := Γ.eval [] (by trivial)
 
 /-- Inductively define a polynomial `Γ'` so that (up to the fact that we haven't
-defined reduction on polynomials) `Γ' ⬝ t ⇒* Γ[xₙ ← t]`. -/
+defined reduction on polynomials) `Γ' ⬝ t ↠ Γ[xₙ ← t]`. -/
 def Polynomial.elimVar {n : Nat} : SKI.Polynomial (n+1) → SKI.Polynomial n
   /- The K-combinator leaves plain terms unchanged by substitution `K ⬝ x ⬝ t ⇒ x` -/
   | SKI.Polynomial.term x => K ⬝' x
@@ -83,7 +83,7 @@ for the inner variables.
 -/
 theorem Polynomial.elimVar_correct {n : Nat} (Γ : SKI.Polynomial (n+1)) {ys : List SKI}
     (hys : ys.length = n) (z : SKI) :
-    Γ.elimVar.eval ys hys ⬝ z ⇒* Γ.eval (ys ++ [z])
+    Γ.elimVar.eval ys hys ⬝ z ↠ Γ.eval (ys ++ [z])
       (by rw [List.length_append, hys, List.length_singleton])
     := by
   match n, Γ with
@@ -125,13 +125,13 @@ def Polynomial.toSKI {n : Nat} (Γ : SKI.Polynomial n) : SKI :=
 
 /-- Correctness for the toSKI (bracket abstraction) algorithm. -/
 theorem Polynomial.toSKI_correct {n : Nat} (Γ : SKI.Polynomial n) (xs : List SKI)
-    (hxs : xs.length = n) : Γ.toSKI.applyList xs ⇒* Γ.eval xs hxs := by
+    (hxs : xs.length = n) : Γ.toSKI.applyList xs ↠ Γ.eval xs hxs := by
   match n with
   | 0 =>
     unfold toSKI varFreeToSKI applyList
     rw [List.length_eq_zero_iff] at hxs
     simp_rw [hxs, List.foldl_nil]
-    apply MRed.refl
+    rfl
   | n+1 =>
     -- show that xs = ys + [z]
     have : xs ≠ [] := List.ne_nil_of_length_eq_add_one hxs
@@ -165,7 +165,7 @@ choose a descriptive name.
 def RPoly : SKI.Polynomial 2 := &1 ⬝' &0
 /-- A SKI term representing R -/
 def R : SKI := RPoly.toSKI
-theorem R_def (x y : SKI) : R ⬝ x ⬝ y ⇒* y ⬝ x :=
+theorem R_def (x y : SKI) : R ⬝ x ⬝ y ↠ y ⬝ x :=
   RPoly.toSKI_correct [x, y] (by simp)
 
 
@@ -173,7 +173,7 @@ theorem R_def (x y : SKI) : R ⬝ x ⬝ y ⇒* y ⬝ x :=
 def BPoly : SKI.Polynomial 3 := &0 ⬝' (&1 ⬝' &2)
 /-- A SKI term representing B -/
 def B : SKI := BPoly.toSKI
-theorem B_def (f g x : SKI) : B ⬝ f ⬝ g ⬝ x ⇒* f ⬝ (g ⬝ x) :=
+theorem B_def (f g x : SKI) : B ⬝ f ⬝ g ⬝ x ↠ f ⬝ (g ⬝ x) :=
   BPoly.toSKI_correct [f, g, x] (by simp)
 
 
@@ -181,7 +181,7 @@ theorem B_def (f g x : SKI) : B ⬝ f ⬝ g ⬝ x ⇒* f ⬝ (g ⬝ x) :=
 def CPoly : SKI.Polynomial 3 := &0 ⬝' &2 ⬝' &1
 /-- A SKI term representing C -/
 def C : SKI := CPoly.toSKI
-theorem C_def (f x y : SKI) : C ⬝ f ⬝ x ⬝ y ⇒* f ⬝ y ⬝ x :=
+theorem C_def (f x y : SKI) : C ⬝ f ⬝ x ⬝ y ↠ f ⬝ y ⬝ x :=
   CPoly.toSKI_correct [f, x, y] (by simp)
 
 
@@ -189,7 +189,7 @@ theorem C_def (f x y : SKI) : C ⬝ f ⬝ x ⬝ y ⇒* f ⬝ y ⬝ x :=
 def RotRPoly : SKI.Polynomial 3 := &2 ⬝' &0 ⬝' &1
 /-- A SKI term representing RotR -/
 def RotR : SKI := RotRPoly.toSKI
-theorem rotR_def (x y z : SKI) : RotR ⬝ x ⬝ y ⬝ z ⇒* z ⬝ x ⬝ y :=
+theorem rotR_def (x y z : SKI) : RotR ⬝ x ⬝ y ⬝ z ↠ z ⬝ x ⬝ y :=
   RotRPoly.toSKI_correct [x, y, z] (by simp)
 
 
@@ -197,7 +197,7 @@ theorem rotR_def (x y z : SKI) : RotR ⬝ x ⬝ y ⬝ z ⇒* z ⬝ x ⬝ y :=
 def RotLPoly : SKI.Polynomial 3 := &1 ⬝' &2 ⬝' &0
 /-- A SKI term representing RotL -/
 def RotL : SKI := RotLPoly.toSKI
-theorem rotL_def (x y z : SKI) : RotL ⬝ x ⬝ y ⬝ z ⇒* y ⬝ z ⬝ x :=
+theorem rotL_def (x y z : SKI) : RotL ⬝ x ⬝ y ⬝ z ↠ y ⬝ z ⬝ x :=
   RotLPoly.toSKI_correct [x, y, z] (by simp)
 
 
@@ -205,7 +205,7 @@ theorem rotL_def (x y z : SKI) : RotL ⬝ x ⬝ y ⬝ z ⇒* y ⬝ z ⬝ x :=
 def δPoly : SKI.Polynomial 1 := &0 ⬝' &0
 /-- A SKI term representing δ -/
 def δ : SKI := δPoly.toSKI
-theorem δ_def (x : SKI) : δ ⬝ x ⇒* x ⬝ x :=
+theorem δ_def (x : SKI) : δ ⬝ x ↠ x ⬝ x :=
   δPoly.toSKI_correct [x] (by simp)
 
 
@@ -213,7 +213,7 @@ theorem δ_def (x : SKI) : δ ⬝ x ⇒* x ⬝ x :=
 def HPoly : SKI.Polynomial 2 := &0 ⬝' (&1 ⬝' &1)
 /-- A SKI term representing H -/
 def H : SKI := HPoly.toSKI
-theorem H_def (f x : SKI) : H ⬝ f ⬝ x ⇒* f ⬝ (x ⬝ x) :=
+theorem H_def (f x : SKI) : H ⬝ f ⬝ x ↠ f ⬝ (x ⬝ x) :=
   HPoly.toSKI_correct [f, x] (by simp)
 
 
@@ -221,7 +221,7 @@ theorem H_def (f x : SKI) : H ⬝ f ⬝ x ⇒* f ⬝ (x ⬝ x) :=
 def YPoly : SKI.Polynomial 1 := H ⬝' &0 ⬝' (H ⬝' &0)
 /-- A SKI term representing Y -/
 def Y : SKI := YPoly.toSKI
-theorem Y_def (f : SKI) : Y ⬝ f ⇒* H ⬝ f ⬝ (H ⬝ f) :=
+theorem Y_def (f : SKI) : Y ⬝ f ↠ H ⬝ f ⬝ (H ⬝ f) :=
   YPoly.toSKI_correct [f] (by simp)
 
 
@@ -239,29 +239,29 @@ rather than up to a common reduct. An alternative is to use Turing's fixed-point
 (defined below).
 -/
 def fixedPoint (f : SKI) : SKI := H ⬝ f ⬝ (H ⬝ f)
-theorem fixedPoint_correct (f : SKI) : f.fixedPoint ⇒* f ⬝ f.fixedPoint := H_def f (H ⬝ f)
+theorem fixedPoint_correct (f : SKI) : f.fixedPoint ↠ f ⬝ f.fixedPoint := H_def f (H ⬝ f)
 
 /-- Auxiliary definition for Turing's fixed-point combinator: ΘAux := λ x y. y (x x y) -/
 def ΘAuxPoly : SKI.Polynomial 2 := &1 ⬝' (&0 ⬝' &0 ⬝' &1)
 /-- A term representing ΘAux -/
 def ΘAux : SKI := ΘAuxPoly.toSKI
-theorem ΘAux_def (x y : SKI) : ΘAux ⬝ x ⬝ y ⇒* y ⬝ (x ⬝ x ⬝ y) :=
+theorem ΘAux_def (x y : SKI) : ΘAux ⬝ x ⬝ y ↠ y ⬝ (x ⬝ x ⬝ y) :=
   ΘAuxPoly.toSKI_correct [x, y] (by simp)
 
 
 /--Turing's fixed-point combinator: Θ := (λ x y. y (x x y)) (λ x y. y (x x y)) -/
 def Θ : SKI := ΘAux ⬝ ΘAux
 /-- A SKI term representing Θ -/
-theorem Θ_correct (f : SKI) : Θ ⬝ f ⇒* f ⬝ (Θ ⬝ f) := ΘAux_def ΘAux f
+theorem Θ_correct (f : SKI) : Θ ⬝ f ↠ f ⬝ (Θ ⬝ f) := ΘAux_def ΘAux f
 
 
 /-! ### Church Booleans -/
 
 /-- A term a represents the boolean value u if it is βη-equivalent to a standard Church boolean. -/
 def IsBool (u : Bool) (a : SKI) : Prop :=
-  ∀ x y : SKI, a ⬝ x ⬝ y ⇒* (if u then x else y)
+  ∀ x y : SKI, a ⬝ x ⬝ y ↠ (if u then x else y)
 
-theorem isBool_trans (u : Bool) (a a' : SKI) (h : a ⇒* a') (ha' : IsBool u a') :
+theorem isBool_trans (u : Bool) (a a' : SKI) (h : a ↠ a') (ha' : IsBool u a') :
     IsBool u a := by
   intro x y
   trans a' ⬝ x ⬝ y
@@ -278,13 +278,13 @@ theorem TT_correct : IsBool true TT := fun x y ↦ MRed.K x y
 def FF : SKI := K ⬝ I
 theorem FF_correct : IsBool false FF :=
   fun x y ↦ calc
-    FF ⬝ x ⬝ y ⇒ I ⬝ y := by apply red_head; exact red_K I x
-    _         ⇒ y := red_I y
+    FF ⬝ x ⬝ y ⭢ I ⬝ y := by apply red_head; exact red_K I x
+    _         ⭢ y := red_I y
 
 /-- Conditional: Cond x y b := if b then x else y -/
 protected def Cond : SKI := RotR
 theorem cond_correct (a x y : SKI) (u : Bool) (h : IsBool u a) :
-    SKI.Cond ⬝ x ⬝ y ⬝ a ⇒* if u then x else y := by
+    SKI.Cond ⬝ x ⬝ y ⬝ a ↠ if u then x else y := by
   trans a ⬝ x ⬝ y
   · exact rotR_def x y a
   · exact h x y
@@ -302,7 +302,7 @@ theorem neg_correct (a : SKI) (ua : Bool) (h : IsBool ua a) : IsBool (¬ ua) (SK
 def AndPoly : SKI.Polynomial 2 := SKI.Cond ⬝' (SKI.Cond ⬝ TT ⬝ FF ⬝' &1) ⬝' FF ⬝' &0
 /-- A SKI term representing And -/
 protected def And : SKI := AndPoly.toSKI
-theorem and_def (a b : SKI) : SKI.And ⬝ a ⬝ b ⇒* SKI.Cond ⬝ (SKI.Cond ⬝ TT ⬝ FF ⬝ b) ⬝ FF ⬝ a :=
+theorem and_def (a b : SKI) : SKI.And ⬝ a ⬝ b ↠ SKI.Cond ⬝ (SKI.Cond ⬝ TT ⬝ FF ⬝ b) ⬝ FF ⬝ a :=
   AndPoly.toSKI_correct [a, b] (by simp)
 
 theorem and_correct (a b : SKI) (ua ub : Bool) (ha : IsBool ua a) (hb : IsBool ub b) :
@@ -321,7 +321,7 @@ theorem and_correct (a b : SKI) (ua ub : Bool) (ha : IsBool ua a) (hb : IsBool u
 def OrPoly : SKI.Polynomial 2 := SKI.Cond ⬝' TT ⬝' (SKI.Cond ⬝ TT ⬝ FF ⬝' &1) ⬝' &0
 /-- A SKI term representing Or -/
 protected def Or : SKI := OrPoly.toSKI
-theorem or_def (a b : SKI) : SKI.Or ⬝ a ⬝ b ⇒* SKI.Cond ⬝ TT ⬝ (SKI.Cond ⬝ TT ⬝ FF ⬝ b) ⬝ a :=
+theorem or_def (a b : SKI) : SKI.Or ⬝ a ⬝ b ↠ SKI.Cond ⬝ TT ⬝ (SKI.Cond ⬝ TT ⬝ FF ⬝ b) ⬝ a :=
   OrPoly.toSKI_correct [a, b] (by simp)
 
 theorem or_correct (a b : SKI) (ua ub : Bool) (ha : IsBool ua a) (hb : IsBool ub b) :
@@ -350,22 +350,22 @@ def Fst : SKI := R ⬝ TT
 /-- Second projection -/
 def Snd : SKI := R ⬝ FF
 
-theorem fst_correct (a b : SKI) : Fst ⬝ (MkPair ⬝ a ⬝ b) ⇒* a := by calc
-  _ ⇒* SKI.Cond ⬝ a ⬝ b ⬝ TT := R_def _ _
-  _ ⇒* a := cond_correct TT a b true TT_correct
+theorem fst_correct (a b : SKI) : Fst ⬝ (MkPair ⬝ a ⬝ b) ↠ a := by calc
+  _ ↠ SKI.Cond ⬝ a ⬝ b ⬝ TT := R_def _ _
+  _ ↠ a := cond_correct TT a b true TT_correct
 
-theorem snd_correct (a b : SKI) : Snd ⬝ (MkPair ⬝ a ⬝ b) ⇒* b := by calc
-  _ ⇒* SKI.Cond ⬝ a ⬝ b ⬝ FF := R_def _ _
-  _ ⇒* b := cond_correct FF a b false FF_correct
+theorem snd_correct (a b : SKI) : Snd ⬝ (MkPair ⬝ a ⬝ b) ↠ b := by calc
+  _ ↠ SKI.Cond ⬝ a ⬝ b ⬝ FF := R_def _ _
+  _ ↠ b := cond_correct FF a b false FF_correct
 
 /-- Unpaired f ⟨x, y⟩ := f x y, cf `Nat.unparied`. -/
 def UnpairedPoly : SKI.Polynomial 2 := &0 ⬝' (Fst ⬝' &1) ⬝' (Snd ⬝' &1)
 /-- A term representing Unpaired -/
 protected def Unpaired : SKI := UnpairedPoly.toSKI
-theorem unpaired_def (f p : SKI) : SKI.Unpaired ⬝ f ⬝ p ⇒* f ⬝ (Fst ⬝ p) ⬝ (Snd ⬝ p) :=
+theorem unpaired_def (f p : SKI) : SKI.Unpaired ⬝ f ⬝ p ↠ f ⬝ (Fst ⬝ p) ⬝ (Snd ⬝ p) :=
   UnpairedPoly.toSKI_correct [f, p] (by simp)
 
-theorem unpaired_correct (f x y : SKI) : SKI.Unpaired ⬝ f ⬝ (MkPair ⬝ x ⬝ y) ⇒* f ⬝ x ⬝ y := by
+theorem unpaired_correct (f x y : SKI) : SKI.Unpaired ⬝ f ⬝ (MkPair ⬝ x ⬝ y) ↠ f ⬝ x ⬝ y := by
   trans f ⬝ (Fst ⬝ (MkPair ⬝ x ⬝ y)) ⬝ (Snd ⬝ (MkPair ⬝ x ⬝ y))
   . exact unpaired_def f _
   . apply parallel_mRed
@@ -377,5 +377,5 @@ theorem unpaired_correct (f x y : SKI) : SKI.Unpaired ⬝ f ⬝ (MkPair ⬝ x �
 def PairPoly : SKI.Polynomial 3 := MkPair ⬝' (&0 ⬝' &2) ⬝' (&1 ⬝' &2)
 /-- A SKI term representing Pair -/
 protected def Pair : SKI := PairPoly.toSKI
-theorem pair_def (f g x : SKI) : SKI.Pair ⬝ f ⬝ g ⬝ x ⇒* MkPair ⬝ (f ⬝ x) ⬝ (g ⬝ x) :=
+theorem pair_def (f g x : SKI) : SKI.Pair ⬝ f ⬝ g ⬝ x ↠ MkPair ⬝ (f ⬝ x) ⬝ (g ⬝ x) :=
   PairPoly.toSKI_correct [f, g, x] (by simp)

--- a/Cslib/Computability/CombinatoryLogic/Confluence.lean
+++ b/Cslib/Computability/CombinatoryLogic/Confluence.lean
@@ -9,11 +9,11 @@ import Cslib.Utils.Relation
 /-!
 # SKI reduction is confluent
 
-This file proves the **Church-Rosser** theorem for the SKI calculus, that is, if `a ⇒* b` and
-`a ⇒* c`, `b ⇒* d` and `c ⇒* d` for some term `d`. More strongly (though equivalently), we show
+This file proves the **Church-Rosser** theorem for the SKI calculus, that is, if `a ↠ b` and
+`a ↠ c`, `b ↠ d` and `c ↠ d` for some term `d`. More strongly (though equivalently), we show
 that the relation of having a common reduct is transitive — in the above situation, `a` and `b`,
 and `a` and `c` have common reducts, so the result implies the same of `b` and `c`. Note that
-`CommonReduct` is symmetric (trivially) and reflexive (since `⇒*` is), so we in fact show that
+`CommonReduct` is symmetric (trivially) and reflexive (since `↠` is), so we in fact show that
 `CommonReduct` is an equivalence.
 
 Our proof
@@ -23,7 +23,7 @@ Chapter 4 of Peter Selinger's notes:
 
 ## Main definitions
 
-- `ParallelReduction` : a relation `⇒ₚ` on terms such that `⇒ ⊆ ⇒ₚ ⊆ ⇒*`, allowing simultaneous
+- `ParallelReduction` : a relation `⇒ₚ` on terms such that `⇒ ⊆ ⇒ₚ ⊆ ↠`, allowing simultaneous
 reduction on the head and tail of a term.
 
 ## Main results
@@ -31,13 +31,13 @@ reduction on the head and tail of a term.
 - `parallelReduction_diamond` : parallel reduction satisfies the diamond property, that is, it is
 confluent in a single step.
 - `commonReduct_equivalence` : by a general result, the diamond property for `⇒ₚ` implies the same
-for its reflexive-transitive closure. This closure is exactly `⇒*`, which implies the
+for its reflexive-transitive closure. This closure is exactly `↠`, which implies the
 **Church-Rosser** theorem as sketched above.
 -/
 
 namespace SKI
 
-open Red MRed
+open Red MRed ReductionSystem
 
 /-- A reduction step allowing simultaneous reduction of disjoint redexes -/
 inductive ParallelReduction : SKI → SKI → Prop
@@ -55,8 +55,8 @@ inductive ParallelReduction : SKI → SKI → Prop
 /-- Notation for parallel reduction -/
 scoped infix:90 " ⇒ₚ " => ParallelReduction
 
-/-- The inclusion `⇒ₚ ⊆ ⇒*` -/
-theorem mRed_of_parallelReduction {a a' : SKI} (h : a ⇒ₚ a') : a ⇒* a' := by
+/-- The inclusion `⇒ₚ ⊆ ↠` -/
+theorem mRed_of_parallelReduction {a a' : SKI} (h : a ⇒ₚ a') : a ↠ a' := by
   cases h
   case refl => exact Relation.ReflTransGen.refl
   case par a a' b b' ha hb =>
@@ -68,7 +68,7 @@ theorem mRed_of_parallelReduction {a a' : SKI} (h : a ⇒ₚ a') : a ⇒* a' := 
   case red_S a b c => exact Relation.ReflTransGen.single (red_S a b c)
 
 /-- The inclusion `⇒ ⊆ ⇒ₚ` -/
-theorem parallelReduction_of_red {a a' : SKI} (h : a ⇒ a') : a ⇒ₚ a' := by
+theorem parallelReduction_of_red {a a' : SKI} (h : a ⭢ a') : a ⇒ₚ a' := by
   cases h
   case red_S => apply ParallelReduction.red_S
   case red_K => apply ParallelReduction.red_K
@@ -86,12 +86,12 @@ theorem parallelReduction_of_red {a a' : SKI} (h : a ⇒ a') : a ⇒ₚ a' := by
 `parallelReduction_of_red` imply that `⇒` and `⇒ₚ` have the same reflexive-transitive
 closure. -/
 theorem reflTransGen_parallelReduction_mRed :
-    Relation.ReflTransGen ParallelReduction = MRed := by
+    Relation.ReflTransGen ParallelReduction = RedSKI.MRed := by
   ext a b
   constructor
   · apply Relation.reflTransGen_minimal
-    · exact MRed.reflexive
-    · exact MRed.transitive
+    · exact λ _ => by rfl
+    · exact instTransitiveMRed RedSKI
     · exact @mRed_of_parallelReduction
   · apply Relation.reflTransGen_minimal
     · exact Relation.reflexive_reflTransGen
@@ -101,7 +101,7 @@ theorem reflTransGen_parallelReduction_mRed :
 /-!
 Irreducibility for the (partially applied) primitive combinators.
 
-TODO: possibly these should be proven more generally (in another file) for `⇒*`.
+TODO: possibly these should be proven more generally (in another file) for `↠`.
 -/
 
 lemma I_irreducible (a : SKI) (h : I ⇒ₚ a) : a = I := by
@@ -233,7 +233,7 @@ theorem commonReduct_equivalence : Equivalence CommonReduct := by
   exact join_parallelReduction_equivalence
 
 /-- The **Church-Rosser** theorem in the form it is usually stated. -/
-theorem MRed.diamond (a b c : SKI) (hab : a ⇒* b) (hac : a ⇒* c) : CommonReduct b c := by
+theorem MRed.diamond (a b c : SKI) (hab : a ↠ b) (hac : a ↠ c) : CommonReduct b c := by
   apply commonReduct_equivalence.trans (y := a)
   · exact commonReduct_equivalence.symm (commonReduct_of_single hab)
   · exact commonReduct_of_single hac

--- a/Cslib/Computability/CombinatoryLogic/Defs.lean
+++ b/Cslib/Computability/CombinatoryLogic/Defs.lean
@@ -57,6 +57,12 @@ lemma applyList_concat (f : SKI) (ys : List SKI) (z : SKI) :
     f.applyList (ys ++ [z]) = f.applyList ys ⬝ z := by
   simp [applyList]
 
+/-- The size of an SKI term is its number of combinators. -/
+def size : SKI → Nat
+  | S => 1
+  | K => 1
+  | I => 1
+  | x ⬝ y => size x + size y
 
 /-! ### Reduction relations between SKI terms -/
 
@@ -136,3 +142,9 @@ lemma commonReduct_of_single {a b : SKI} (h : a ↠ b) : CommonReduct a b := ⟨
 theorem symmetric_commonReduct : Symmetric CommonReduct := Relation.symmetric_join
 theorem reflexive_commonReduct : Reflexive CommonReduct := λ x => by
   refine ⟨x,?_,?_⟩ <;> rfl
+
+theorem commonReduct_head {x x' : SKI} (y : SKI) : CommonReduct x x' → CommonReduct (x ⬝ y) (x' ⬝ y)
+  | ⟨z, hz, hz'⟩ => ⟨z ⬝ y, MRed.head y hz, MRed.head y hz'⟩
+
+theorem commonReduct_tail (x : SKI) {y y' : SKI} : CommonReduct y y' → CommonReduct (x ⬝ y) (x ⬝ y')
+  | ⟨z, hz, hz'⟩ => ⟨x ⬝ z, MRed.tail x hz, MRed.tail x hz'⟩

--- a/Cslib/Computability/CombinatoryLogic/Defs.lean
+++ b/Cslib/Computability/CombinatoryLogic/Defs.lean
@@ -77,6 +77,13 @@ inductive Red : SKI → SKI → Prop where
 
 open Red ReductionSystem
 
+lemma Red.ne {x y : SKI} : (x ⭢ y) → x ≠ y
+  | red_S _ _ _, h => by cases h
+  | red_K _ _, h => by cases h
+  | red_I _, h => by cases h
+  | red_head _ _ _ h', h => Red.ne h' (SKI.app.inj h).1
+  | red_tail _ _ _ h', h => Red.ne h' (SKI.app.inj h).2
+
 theorem MRed.S (x y z : SKI) : (S ⬝ x ⬝ y ⬝ z) ↠ (x ⬝ z ⬝ (y ⬝ z)) := MRed.single RedSKI <| red_S ..
 theorem MRed.K (x y : SKI) : (K ⬝ x ⬝ y) ↠ x := MRed.single RedSKI <| red_K ..
 theorem MRed.I (x : SKI) : (I ⬝ x) ↠ x := MRed.single RedSKI <| red_I ..

--- a/Cslib/Computability/CombinatoryLogic/Defs.lean
+++ b/Cslib/Computability/CombinatoryLogic/Defs.lean
@@ -5,6 +5,7 @@ Authors: Thomas Waring
 -/
 import Mathlib.Logic.Relation
 import Cslib.Utils.Relation
+import Cslib.Semantics.ReductionSystem.Basic
 
 /-!
 # SKI Combinatory Logic
@@ -23,7 +24,7 @@ using the SKI basis.
 
 - `⬝` : application between SKI terms,
 - `⇒` : single-step reduction,
-- `⇒*` : multi-step reduction,
+- `↠` : multi-step reduction,
 
 ## References
 
@@ -60,6 +61,7 @@ lemma applyList_concat (f : SKI) (ys : List SKI) (z : SKI) :
 /-! ### Reduction relations between SKI terms -/
 
 /-- Single-step reduction of SKI terms -/
+@[reduction_sys RedSKI]
 inductive Red : SKI → SKI → Prop where
   /-- The operational semantics of the `S`, -/
   | red_S (x y z : SKI) : Red (S ⬝ x ⬝ y ⬝ z) (x ⬝ z ⬝ (y ⬝ z))
@@ -72,60 +74,47 @@ inductive Red : SKI → SKI → Prop where
   /-- and tail of an SKI term. -/
   | red_tail (x y y' : SKI) (_ : Red y y') : Red (x ⬝ y) (x ⬝ y')
 
-/-- Notation for single-step reduction -/
-scoped infix:90 " ⇒ " => Red
 
-/-- Multi-step reduction of SKI terms -/
-def MRed : SKI → SKI → Prop := Relation.ReflTransGen Red
+open Red ReductionSystem
 
-/-- Notation for multi-step reduction (by analogy with the Kleene star) -/
-scoped infix:90 " ⇒* " => MRed
+theorem MRed.S (x y z : SKI) : (S ⬝ x ⬝ y ⬝ z) ↠ (x ⬝ z ⬝ (y ⬝ z)) := MRed.single RedSKI <| red_S ..
+theorem MRed.K (x y : SKI) : (K ⬝ x ⬝ y) ↠ x := MRed.single RedSKI <| red_K ..
+theorem MRed.I (x : SKI) : (I ⬝ x) ↠ x := MRed.single RedSKI <| red_I ..
 
-open Red
-
-@[refl]
-theorem MRed.refl (a : SKI) : a ⇒* a := Relation.ReflTransGen.refl
-
-theorem MRed.single {a b : SKI} (h : a ⇒ b) : a ⇒* b := Relation.ReflTransGen.single h
-
-theorem MRed.S (x y z : SKI) : MRed (S ⬝ x ⬝ y ⬝ z) (x ⬝ z ⬝ (y ⬝ z)) := MRed.single <| red_S ..
-theorem MRed.K (x y : SKI) : MRed (K ⬝ x ⬝ y) x := MRed.single <| red_K ..
-theorem MRed.I (x : SKI) : MRed (I ⬝ x) x := MRed.single <| red_I ..
-
-theorem MRed.head {a a' : SKI} (b : SKI) (h : a ⇒* a') : (a ⬝ b) ⇒* (a' ⬝ b) := by
+theorem MRed.head {a a' : SKI} (b : SKI) (h : a ↠ a') : (a ⬝ b) ↠ (a' ⬝ b) := by
   induction h with
   | refl => apply MRed.refl
   | @tail a' a'' _ ha'' ih =>
     apply Relation.ReflTransGen.tail (b := a' ⬝ b) ih
     exact Red.red_head a' a'' b ha''
 
-theorem MRed.tail (a : SKI) {b b' : SKI} (h : b ⇒* b') : (a ⬝ b) ⇒* (a ⬝ b') := by
+theorem MRed.tail (a : SKI) {b b' : SKI} (h : b ↠ b') : (a ⬝ b) ↠ (a ⬝ b') := by
   induction h with
   | refl => apply MRed.refl
   | @tail b' b'' _ hb'' ih =>
     apply Relation.ReflTransGen.tail (b := a ⬝ b') ih
     exact Red.red_tail a b' b'' hb''
 
-instance MRed.instTrans : IsTrans SKI MRed := Relation.instIsTransReflTransGen
-theorem MRed.transitive : Transitive MRed := transitive_of_trans MRed
+-- instance MRed.instTrans : IsTrans SKI MRed := Relation.instIsTransReflTransGen
+-- theorem MRed.transitive : Transitive MRed := transitive_of_trans MRed
 
-instance MRed.instIsRefl : IsRefl SKI MRed := Relation.instIsReflReflTransGen
-theorem MRed.reflexive : Reflexive MRed := IsRefl.reflexive
+-- instance MRed.instIsRefl : IsRefl SKI MRed := Relation.instIsReflReflTransGen
+-- theorem MRed.reflexive : Reflexive MRed := IsRefl.reflexive
 
-instance MRedTrans : Trans Red MRed MRed :=
-  ⟨fun hab => Relation.ReflTransGen.trans (MRed.single hab)⟩
+-- instance MRedTrans : Trans Red MRed MRed :=
+--   ⟨fun hab => Relation.ReflTransGen.trans (MRed.single hab)⟩
 
-instance MRedRedTrans : Trans MRed Red MRed :=
-  ⟨fun hab hbc => Relation.ReflTransGen.trans hab (MRed.single hbc)⟩
+-- instance MRedRedTrans : Trans MRed Red MRed :=
+--   ⟨fun hab hbc => Relation.ReflTransGen.trans hab (MRed.single hbc)⟩
 
-instance RedMRedTrans : Trans Red Red MRed :=
-  ⟨fun hab hbc => Relation.ReflTransGen.trans (MRed.single hab) (MRed.single hbc)⟩
+-- instance RedMRedTrans : Trans Red Red MRed :=
+--   ⟨fun hab hbc => Relation.ReflTransGen.trans (MRed.single hab) (MRed.single hbc)⟩
 
-lemma parallel_mRed {a a' b b' : SKI} (ha : a ⇒* a') (hb : b ⇒* b') :
-    (a ⬝ b) ⇒* (a' ⬝ b') :=
+lemma parallel_mRed {a a' b b' : SKI} (ha : a ↠ a') (hb : b ↠ b') :
+    (a ⬝ b) ↠ (a' ⬝ b') :=
   Trans.simple (MRed.head b ha) (MRed.tail a' hb)
 
-lemma parallel_red {a a' b b' : SKI} (ha : a ⇒ a') (hb : b ⇒ b') : (a ⬝ b) ⇒* (a' ⬝ b') := by
+lemma parallel_red {a a' b b' : SKI} (ha : a ⭢ a') (hb : b ⭢ b') : (a ⬝ b) ↠ (a' ⬝ b') := by
   trans a' ⬝ b
   all_goals apply MRed.single
   · exact Red.red_head a a' b ha
@@ -133,11 +122,10 @@ lemma parallel_red {a a' b b' : SKI} (ha : a ⇒ a') (hb : b ⇒ b') : (a ⬝ b)
 
 
 /-- Express that two terms have a reduce to a common term. -/
-def CommonReduct : SKI → SKI → Prop := Relation.Join MRed
+def CommonReduct : SKI → SKI → Prop := Relation.Join RedSKI.MRed
 
-lemma commonReduct_of_single {a b : SKI} (h : a ⇒* b) : CommonReduct a b := by
-  refine Relation.join_of_single MRed.reflexive h
+lemma commonReduct_of_single {a b : SKI} (h : a ↠ b) : CommonReduct a b := ⟨b, h, by rfl⟩
 
 theorem symmetric_commonReduct : Symmetric CommonReduct := Relation.symmetric_join
-theorem reflexive_commonReduct : Reflexive CommonReduct :=
-  Relation.reflexive_join MRed.reflexive
+theorem reflexive_commonReduct : Reflexive CommonReduct := λ x => by
+  refine ⟨x,?_,?_⟩ <;> rfl

--- a/Cslib/Computability/CombinatoryLogic/Evaluation.lean
+++ b/Cslib/Computability/CombinatoryLogic/Evaluation.lean
@@ -1,0 +1,179 @@
+/-
+Copyright (c) 2025 Thomas Waring. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Thomas Waring
+-/
+import Cslib.Computability.CombinatoryLogic.Defs
+import Cslib.Computability.CombinatoryLogic.Confluence
+
+/-!
+# Evaluation results
+
+This file draws heavily from <https://gist.github.com/b-mehta/e412c837818223b8f16ca0b4aa19b166>
+-/
+
+open SKI Red
+
+/-- The predicate that a term has no reducible sub-terms. -/
+def RedexFree : SKI → Prop
+  | S => True
+  | K => True
+  | I => True
+  | S ⬝ x => RedexFree x
+  | K ⬝ x => RedexFree x
+  | I ⬝ _ => False
+  | S ⬝ x ⬝ y => RedexFree x ∧ RedexFree y
+  | K ⬝ _ ⬝ _ => False
+  | I ⬝ _ ⬝ _ => False
+  | S ⬝ _ ⬝ _ ⬝ _ => False
+  | K ⬝ _ ⬝ _ ⬝ _ => False
+  | I ⬝ _ ⬝ _ ⬝ _ => False
+  | a ⬝ b ⬝ c ⬝ d ⬝ e => RedexFree (a ⬝ b ⬝ c ⬝ d) ∧ RedexFree e
+
+/--
+One-step evaluation as a function: either it returns a term that has been reduced by one step,
+or a proof that the term is redex free. Uses normal-order reduction.
+-/
+def evalStep : (x : SKI) → PLift (RedexFree x) ⊕ SKI
+  | S => Sum.inl (PLift.up trivial)
+  | K => Sum.inl (PLift.up trivial)
+  | I => Sum.inl (PLift.up trivial)
+  | S ⬝ x => match evalStep x with
+    | Sum.inl h => Sum.inl h
+    | Sum.inr x' => Sum.inr (S ⬝ x')
+  | K ⬝ x => match evalStep x with
+    | Sum.inl h => Sum.inl h
+    | Sum.inr x' => Sum.inr (K ⬝ x')
+  | I ⬝ x => Sum.inr x
+  | S ⬝ x ⬝ y => match evalStep x, evalStep y with
+    | Sum.inl h1, Sum.inl h2 => Sum.inl (.up ⟨h1.down, h2.down⟩)
+    | Sum.inl _, Sum.inr y' => Sum.inr (S ⬝ x ⬝ y')
+    | Sum.inr x', _ => Sum.inr (S ⬝ x' ⬝ y)
+  | K ⬝ x ⬝ _ => Sum.inr x
+  | I ⬝ x ⬝ y => Sum.inr (x ⬝ y)
+  | S ⬝ x ⬝ y ⬝ z => Sum.inr (x ⬝ z ⬝ (y ⬝ z))
+  | K ⬝ x ⬝ _ ⬝ z => Sum.inr (x ⬝ z)
+  | I ⬝ x ⬝ y ⬝ z => Sum.inr (x ⬝ y ⬝ z)
+  | a ⬝ b ⬝ c ⬝ d ⬝ e => match evalStep (a ⬝ b ⬝ c ⬝ d), evalStep e with
+    | Sum.inl h1, Sum.inl h2 => Sum.inl (.up ⟨h1.down, h2.down⟩)
+    | Sum.inl _, Sum.inr e' => Sum.inr (a ⬝ b ⬝ c ⬝ d ⬝ e')
+    | Sum.inr abcd', _ => Sum.inr (abcd' ⬝ e)
+
+/-- The normal-order reduction implemented by `evalStep` indeed computes a one-step reduction. -/
+theorem evalStep_right_correct : (x y : SKI) → (evalStep x = Sum.inr y) → x ⭢ y
+  | S ⬝ x, a, h =>
+    match hx : evalStep x with
+    | Sum.inl _ => by simp only [hx, evalStep, reduceCtorEq] at h
+    | Sum.inr x' => by
+        simp only [evalStep, hx, Sum.inr.injEq] at h
+        rw [←h]
+        exact .red_tail _ _ _ (evalStep_right_correct _ _ hx)
+  | K ⬝ x, a, h =>
+    match hx : evalStep x with
+    | Sum.inl _ => by simp only [hx, evalStep, reduceCtorEq] at h
+    | Sum.inr x' => by
+        simp only [evalStep, hx, Sum.inr.injEq] at h
+        rw [←h]
+        exact .red_tail _ _ _ (evalStep_right_correct _ _ hx)
+  | I ⬝ x, a, h => Sum.inr.inj h ▸ red_I _
+  | S ⬝ x ⬝ y, a, h =>
+      match hx : evalStep x, hy : evalStep y with
+      | Sum.inl _, Sum.inl _ => by simp only [hx, hy, evalStep, reduceCtorEq] at h
+      | Sum.inl _, Sum.inr y' => by
+          simp only [hx, hy, evalStep, Sum.inr.injEq] at h
+          rw [←h]
+          exact .red_tail _ _ _ <| evalStep_right_correct _ _ hy
+      | Sum.inr x', _ => by
+          simp only [hx, hy, evalStep, Sum.inr.injEq] at h
+          rw [←h]
+          exact .red_head _ _ _ <| .red_tail _ _ _ <| evalStep_right_correct _ _ hx
+  | K ⬝ x ⬝ y, a, h => Sum.inr.inj h ▸ red_K ..
+  | I ⬝ x ⬝ y, a, h => Sum.inr.inj h ▸ (red_head _ _ _ <| red_I _)
+  | S ⬝ x ⬝ y ⬝ z, a, h => Sum.inr.inj h ▸ red_S ..
+  | K ⬝ x ⬝ y ⬝ z, a, h => Sum.inr.inj h ▸ (red_head _ _ _ <| red_K ..)
+  | I ⬝ x ⬝ y ⬝ z, a, h => Sum.inr.inj h ▸ (red_head _ _ _ <| red_head _ _ _ <| red_I _)
+  | a ⬝ b ⬝ c ⬝ d ⬝ e, x, h =>
+      match habcd : evalStep (a ⬝ b ⬝ c ⬝ d), he : evalStep e with
+      | Sum.inl _, Sum.inl _ => by simp only [habcd, he, evalStep, reduceCtorEq] at h
+      | Sum.inl _, Sum.inr e' => by
+          simp only [habcd, he, evalStep, Sum.inr.injEq] at h
+          rw [←h]
+          exact red_tail _ _ _ <| evalStep_right_correct _ _ he
+      | Sum.inr abcd', _ => by
+          simp only [habcd, he, evalStep, Sum.inr.injEq] at h
+          rw [←h]
+          exact red_head _ _ _ <| evalStep_right_correct _ _ habcd
+
+theorem redexFree_of_no_red {x : SKI} (h : ∀ y, ¬ (x ⭢ y)) : RedexFree x := by
+  match hx : evalStep x with
+  | Sum.inl h' => exact h'.down
+  | Sum.inr y => cases h _ (evalStep_right_correct x y hx)
+
+theorem RedexFree.no_red : {x : SKI} → RedexFree x → ∀ y, ¬ (x ⭢ y)
+| S ⬝ x, hx, S ⬝ y, red_tail _ _ _ hx' => by rw [RedexFree] at hx; exact hx.no_red y hx'
+| K ⬝ x, hx, K ⬝ y, red_tail _ _ _ hx' => by rw [RedexFree] at hx; exact hx.no_red y hx'
+| S ⬝ _ ⬝ _, ⟨hx, _⟩, S ⬝ _ ⬝ _, red_head _ _ _ (red_tail _ _ _ h3) => hx.no_red _ h3
+| S ⬝ _ ⬝ _, ⟨_, hy⟩, S ⬝ _ ⬝ _, red_tail _ _ _ h3 => hy.no_red _ h3
+| _ ⬝ _ ⬝ _ ⬝ _ ⬝ _, ⟨hx, _⟩, _ ⬝ _, red_head _ _ _ hq => hx.no_red _ hq
+| _ ⬝ _ ⬝ _ ⬝ _ ⬝ _, ⟨_, hy⟩, _ ⬝ _, red_tail _ _ _ he => hy.no_red _ he
+
+/-- A term is redex free iff it has no one-step reductions. -/
+theorem redexFree_iff {x : SKI} : RedexFree x ↔ ∀ y, ¬ (x ⭢ y) :=
+  ⟨RedexFree.no_red, redexFree_of_no_red⟩
+
+theorem redexFree_iff_onceEval {x : SKI} : RedexFree x ↔ (evalStep x).isLeft = true := by
+  constructor
+  case mp =>
+    intro h
+    match hx : evalStep x with
+    | Sum.inl h' => exact rfl
+    | Sum.inr y => cases h.no_red _ (evalStep_right_correct _ _ hx)
+  case mpr =>
+    intro h
+    match hx : evalStep x with
+    | Sum.inl h' => exact h'.down
+    | Sum.inr y => rw [hx] at h; cases h
+
+instance : DecidablePred RedexFree := fun _ => decidable_of_iff' _ redexFree_iff_onceEval
+
+/-- A term is redex free iff its only many-step reduction is itself. -/
+theorem redexFree_iff' {x : SKI} : RedexFree x ↔ ∀ y, (x ↠ y) ↔ x = y := by
+  constructor
+  case mp =>
+    intro h y
+    constructor
+    case mp =>
+      intro h'
+      cases h'.cases_head
+      case inl => assumption
+      case inr h' =>
+        obtain ⟨z, hz, _⟩ := h'
+        cases h.no_red _ hz
+    case mpr =>
+      intro h
+      rw [h]
+  case mpr =>
+    intro h
+    rw [redexFree_iff]
+    intro y hy
+    specialize h y
+    exact Red.ne hy (h.1 (Relation.ReflTransGen.single hy))
+
+/-- If a term has a common reduct with a normal term, it in fact reduces to that term. -/
+theorem commonReduct_redexFree {x y : SKI} (hy : RedexFree y) (h : CommonReduct x y) : x ↠ y :=
+  let ⟨w, hyw, hzw⟩ := h
+  (redexFree_iff'.1 hy _ |>.1 hzw : y = w) ▸ hyw
+
+/-- If `x` reduces to both `y` and `z`, and `z` is not reducible, then `y` reduces to `z`. -/
+lemma confluent_redexFree {x y z : SKI} (hxy : x ↠ y) (hxz : x ↠ z) (hz : RedexFree z) : y ↠ z :=
+  let ⟨w, hyw, hzw⟩ := MRed.diamond x y z hxy hxz
+  (redexFree_iff'.1 hz _ |>.1 hzw : z = w) ▸ hyw
+
+/--
+If `x` reduces to both `y` and `z`, and both `y` and `z` are in normal form, then they are equal.
+-/
+lemma unique_normal_form {x y z : SKI}
+    (hxy : x ↠ y) (hxz : x ↠ z) (hy : RedexFree y) (hz : RedexFree z) : y = z :=
+  (redexFree_iff'.1 hy _).1 (confluent_redexFree hxy hxz hz)
+
+#check


### PR DESCRIPTION
This pull request extends the development of SKI combinatory logic — adding notions of evaluation and normal forms, and proving a version of [Rice's theorem](https://en.wikipedia.org/wiki/Rice%27s_theorem). The results and definitions are contained in the new file `CombinatoryLogic/Evaluation.lean`, which is based heavily on the [following development](https://gist.github.com/b-mehta/e412c837818223b8f16ca0b4aa19b166) by Bhavik Mehta.

### Notes

The definitions and results of this PR allows us to define normal-order evaluation as a `PFun`, in [the sense of Mathlib](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/PFun.html). The missing piece to make this useful is the so-called _Standardisation theorem_, saying that normal-order reduction will find a normal form, if there is one. The proof of Theorem T9 of Section C in _A Mathematical Logic Without Variables_ (Rosser, 1935) should be amenable to formalization. This would be very interesting, as it ought to define a surjection from SKI terms to, for instance, [partial recursive functions](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Computability/Partrec.html) on the natural numbers, demonstrating that SKI terms are Turing-complete.