### PR TITLE
chore: add weekly linting workflow

### DIFF
--- a/.github/workflows/weekly-lints.yml
+++ b/.github/workflows/weekly-lints.yml
@@ -1,0 +1,57 @@
+name: Weekly linting report
+
+on:
+  schedule:
+    - cron: '0 5 * * 1'  # Run at 05:00 UTC every Monday
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  weekly-lints:
+    name: Weekly Linting
+    runs-on: ubuntu-latest
+    if: github.repository == 'leanprover/cslib'
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: main
+
+    - name: Enable weekly linters
+      run: |
+        # Add the mergeWithGrind linter back for this run
+        sed -i '/^\[leanOptions\]/a weak.linter.tacticAnalysis.mergeWithGrind = true' lakefile.toml
+
+        # Show what changed
+        git diff lakefile.toml
+
+    - name: Configure Lean
+      uses: leanprover/lean-action@v1
+      with:
+        auto-config: false
+        use-github-cache: true
+        use-mathlib-cache: true
+
+    - name: Build with weekly linters
+      id: build
+      continue-on-error: true
+      run: |
+        lean_outfile=$(mktemp)
+        (lake build || true) 2>&1 | tee "${lean_outfile}"
+
+        # Process output for Zulip (simplified reporting)
+        SHA=${{ github.sha }}
+        REPO=${{ github.repository }}
+        RUN_ID=${{ github.run_id }}
+
+        # Generate simplified report
+        ./scripts/weekly_lint_report.sh "${lean_outfile}" "${SHA}" "${REPO}" "${RUN_ID}" >> "${GITHUB_OUTPUT}"
+
+    - name: Post output to Zulip
+      uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5
+      with:
+        api-key: ${{ secrets.ZULIP_API_KEY }}
+        email: 'github-mathlib4-bot@leanprover.zulipchat.com'
+        organization-url: 'https://leanprover.zulipchat.com'
+        to: 'CSLib'
+        type: 'stream'
+        topic: 'Weekly linting log'
+        content: ${{ steps.build.outputs.zulip-message }}

--- a/.github/workflows/weekly-lints.yml
+++ b/.github/workflows/weekly-lints.yml
@@ -37,13 +37,8 @@ jobs:
         lean_outfile=$(mktemp)
         (lake build || true) 2>&1 | tee "${lean_outfile}"
 
-        # Process output for Zulip (simplified reporting)
-        SHA=${{ github.sha }}
-        REPO=${{ github.repository }}
-        RUN_ID=${{ github.run_id }}
-
-        # Generate simplified report
-        ./scripts/weekly_lint_report.sh "${lean_outfile}" "${SHA}" "${REPO}" "${RUN_ID}" >> "${GITHUB_OUTPUT}"
+        # Generate simplified report for Zulip
+        ./scripts/weekly_lint_report.sh "${lean_outfile}" "${{ github.sha }}" "${{ github.repository }}" "${{ github.run_id }}" >> "${GITHUB_OUTPUT}"
 
     - name: Post output to Zulip
       uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -45,3 +45,7 @@ to learn about it as well!
 
 **Init Imports**
 - `CheckInitImports.lean` (usually run from `lake test`) checks that all files transitively import `Cslib.Init`.
+
+**Linting**
+- `weekly_lint_report.sh`
+  Generates a summary of the weekly lint run for posting to Zulip. Called by the `weekly-lints.yml` workflow.

--- a/scripts/weekly_lint_report.sh
+++ b/scripts/weekly_lint_report.sh
@@ -15,14 +15,8 @@ error_count=$(grep -c '^error: ' <<<"${filtered_out}" 2>/dev/null) || error_coun
 warning_count=$(grep -c '^warning: ' <<<"${filtered_out}" 2>/dev/null) || warning_count=0
 info_count=$(grep -c '^info: ' <<<"${filtered_out}" 2>/dev/null) || info_count=0
 
-# Generate output (use uuidgen for cross-platform compatibility)
-if command -v uuidgen >/dev/null 2>&1; then
-  delimiter=$(uuidgen)
-elif [ -f /proc/sys/kernel/random/uuid ]; then
-  delimiter=$(cat /proc/sys/kernel/random/uuid)
-else
-  delimiter="EOF_$(date +%s)"
-fi
+# Generate output
+delimiter=$(cat /proc/sys/kernel/random/uuid)
 
 echo "zulip-message<<${delimiter}"
 echo "CSLib weekly lint run [completed](https://github.com/${REPO}/actions/runs/${RUN_ID}) ([${SHA:0:7}](https://github.com/${REPO}/commit/${SHA}))."

--- a/scripts/weekly_lint_report.sh
+++ b/scripts/weekly_lint_report.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Simplified weekly lint report generator for CSLib
+# Usage: weekly_lint_report.sh <output_file> <sha> <repo> <run_id>
+
+lean_outfile=$1
+SHA=$2
+REPO=$3
+RUN_ID=$4
+
+# Filter out build progress lines and dependency checkout messages
+filtered_out=$(grep -v '^✔' "${lean_outfile}" | grep -v '^trace: ' | grep -v '^info: .* checking out revision')
+
+# Count message types (handle grep returning non-zero exit code when no matches)
+error_count=$(grep -c '^error: ' <<<"${filtered_out}" 2>/dev/null) || error_count=0
+warning_count=$(grep -c '^warning: ' <<<"${filtered_out}" 2>/dev/null) || warning_count=0
+info_count=$(grep -c '^info: ' <<<"${filtered_out}" 2>/dev/null) || info_count=0
+
+# Generate output (use uuidgen for cross-platform compatibility)
+if command -v uuidgen >/dev/null 2>&1; then
+  delimiter=$(uuidgen)
+elif [ -f /proc/sys/kernel/random/uuid ]; then
+  delimiter=$(cat /proc/sys/kernel/random/uuid)
+else
+  delimiter="EOF_$(date +%s)"
+fi
+
+echo "zulip-message<<${delimiter}"
+echo "CSLib weekly lint run [completed](https://github.com/${REPO}/actions/runs/${RUN_ID}) ([${SHA:0:7}](https://github.com/${REPO}/commit/${SHA}))."
+echo ""
+
+if [ "$error_count" -eq 0 ] && [ "$warning_count" -eq 0 ] && [ "$info_count" -eq 0 ]; then
+  echo "Build completed without lint messages."
+else
+  echo "Summary:"
+  [ "$error_count" -gt 0 ] && echo "- Errors: ${error_count}"
+  [ "$warning_count" -gt 0 ] && echo "- Warnings: ${warning_count}"
+  [ "$info_count" -gt 0 ] && echo "- Info messages: ${info_count}"
+fi
+
+echo "${delimiter}"


### PR DESCRIPTION
This adds a weekly linting workflow mimicking Mathlib's approach. It re-enables the mergeWithGrind linter on a weekly cron schedule (Mondays at 05:00 UTC) and posts results to the CSLib Zulip stream. The workflow can also be triggered manually.

Feedback welcome on enriching the report script, for example by emitting the number of grind instances encountered during the build.

Closes #185