### PR TITLE
chore: add dependency instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Or if you're using `lakefile.lean`:
 require cslib from git "https://github.com/leanprover/cslib" @ "main"
 ```
 
-Then run `lake update cslib` to fetch the dependency.
+Then run `lake update cslib` to fetch the dependency. You can also use a release tag instead of `main` for the `rev` value.
 
 # Contributing and discussion
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,24 @@ Cslib aims at formalising Computer Science theories and tools, broadly construed
 - Offer APIs and languages for formalisation projects, software verification, and certified software (among others).
 - Establish a common ground for connecting different developments in Computer Science, in order to foster synergies and reuse.
 
+# Using cslib in your project
+
+To add cslib as a dependency to your Lean project, add the following to your `lakefile.toml`:
+
+```toml
+[[require]]
+name = "cslib"
+git = "https://github.com/leanprover/cslib"
+rev = "main"
+```
+
+Or if you're using `lakefile.lean`:
+
+```lean
+require cslib from git "https://github.com/leanprover/cslib" @ "main"
+```
+
+Then run `lake update cslib` to fetch the dependency.
 
 # Contributing and discussion
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To add cslib as a dependency to your Lean project, add the following to your `la
 ```toml
 [[require]]
 name = "cslib"
-git = "https://github.com/leanprover/cslib"
+scope = "leanprover"
 rev = "main"
 ```
 


### PR DESCRIPTION
Adds a section to the README explaining how to add cslib as a dependency.

Per https://leanprover.zulipchat.com/#narrow/channel/513188-CSLib/topic/.60lake.20new.60.20template.20for.20CSLib.3F/near/562641647