### PR TITLE
feat(Foundations/Data): lawful lenses for verified state access

### DIFF
--- a/Cslib.lean
+++ b/Cslib.lean
@@ -58,6 +58,8 @@ public import Cslib.Foundations.Data.DecidableEqZero
 public import Cslib.Foundations.Data.FinFun.Basic
 public import Cslib.Foundations.Data.FinFun.Update
 public import Cslib.Foundations.Data.HasFresh
+public import Cslib.Foundations.Data.Lens.Basic
+public import Cslib.Foundations.Data.Lens.Examples.MachineState
 public import Cslib.Foundations.Data.Nat.Segment
 public import Cslib.Foundations.Data.OmegaSequence.Defs
 public import Cslib.Foundations.Data.OmegaSequence.Flatten

--- a/Cslib.lean
+++ b/Cslib.lean
@@ -74,6 +74,7 @@ public import Cslib.Foundations.Data.DecidableEqZero
 public import Cslib.Foundations.Data.FinFun.Basic
 public import Cslib.Foundations.Data.FinFun.Update
 public import Cslib.Foundations.Data.HasFresh
+public import Cslib.Foundations.Data.Lens.Basic
 public import Cslib.Foundations.Data.List.IsChainFromTo
 public import Cslib.Foundations.Data.Nat.Segment
 public import Cslib.Foundations.Data.OmegaSequence.Defs

--- a/Cslib/Foundations/Data/Lens/Basic.lean
+++ b/Cslib/Foundations/Data/Lens/Basic.lean
@@ -48,6 +48,8 @@ structure LawfulLens (S A : Type u) extends Lens S A where
 
 namespace Lens
 
+variable {S A B : Type u}
+
 /-- Update the focused component with a function. -/
 def over (l : Lens S A) (f : A → A) : S → S :=
   fun s => l.set s (f (l.get s))
@@ -80,20 +82,18 @@ def mkLawful (get : S → A) (set : S → A → S)
   l.set_set s a b
 
 /-- Composition preserves lawfulness. -/
-theorem comp_lawful (l₁ : LawfulLens S A) (l₂ : LawfulLens A B) :
-    LawfulLens (comp l₁ l₂) where
+def comp_lawful (l₁ : LawfulLens S A) (l₂ : LawfulLens A B) : LawfulLens S B where
+  get := l₂.get ∘ l₁.get
+  set := fun s b => l₁.set s (l₂.set (l₁.get s) b)
   get_set := by
     intro s b
-    dsimp [comp]
-    rw [l₁.get_set, l₂.get_set]
+    simp [l₁.get_set, l₂.get_set]
   set_get := by
     intro s
-    dsimp [comp]
-    rw [l₂.set_get, l₁.set_get]
+    simp [l₁.set_get, l₂.set_get]
   set_set := by
     intro s a b
-    dsimp [comp]
-    rw [l₁.get_set, l₂.set_set, l₁.set_set]
+    simp [l₁.get_set, l₁.set_set, l₂.set_set]
 
 end Lens
 

--- a/Cslib/Foundations/Data/Lens/Basic.lean
+++ b/Cslib/Foundations/Data/Lens/Basic.lean
@@ -21,7 +21,7 @@ Minimal lens API for verified access and update of record-shaped state.
 
 ## Main results
 
-- `Lens.comp_lawful`: composition of lawful lenses is lawful
+- `Lens.compLawful`: composition of lawful lenses is lawful
 -/
 
 @[expose] public section
@@ -58,6 +58,7 @@ def over (l : Lens S A) (f : A → A) : S → S :=
 def comp (l₁ : Lens S A) (l₂ : Lens A B) : Lens S B :=
   ⟨l₂.get ∘ l₁.get, fun s b => l₁.set s (l₂.set (l₁.get s) b)⟩
 
+@[inherit_doc comp]
 infixl:80 " ∘ₗ " => comp
 
 instance : Coe (LawfulLens S A) (Lens S A) := ⟨LawfulLens.toLens⟩
@@ -81,8 +82,8 @@ def mkLawful (get : S → A) (set : S → A → S)
     l.set (l.set s a) b = l.set s b :=
   l.set_set s a b
 
-/-- Composition preserves lawfulness. -/
-def comp_lawful (l₁ : LawfulLens S A) (l₂ : LawfulLens A B) : LawfulLens S B where
+/-- Composition of lawful lenses is lawful. -/
+def compLawful (l₁ : LawfulLens S A) (l₂ : LawfulLens A B) : LawfulLens S B where
   get := l₂.get ∘ l₁.get
   set := fun s b => l₁.set s (l₂.set (l₁.get s) b)
   get_set := by

--- a/Cslib/Foundations/Data/Lens/Basic.lean
+++ b/Cslib/Foundations/Data/Lens/Basic.lean
@@ -8,10 +8,23 @@ module
 
 public import Cslib.Init
 
-/-! # Lawful lenses
+/-!
+# Lawful lenses
 
 Minimal lens API for verified access and update of record-shaped state.
+
+## Main definitions
+
+- `Lens` / `LawfulLens`: getter, setter, and the standard `get_set`, `set_get`, `set_set` laws
+- `Lens.over`: update the focused component with a function
+- `Lens.comp` (`∘ₗ`): compose nested field access
+
+## Main results
+
+- `Lens.comp_lawful`: composition of lawful lenses is lawful
 -/
+
+@[expose] public section
 
 namespace Cslib
 
@@ -24,9 +37,7 @@ structure Lens (S A : Type u) where
   /-- Replace the focused component, leaving the rest of `S` unchanged. -/
   set : S → A → S
 
-/--
-A `LawfulLens` bundles the standard lens laws stated in `get`/`set` vocabulary.
--/
+/-- A `LawfulLens` bundles the standard lens laws stated in `get`/`set` vocabulary. -/
 structure LawfulLens (S A : Type u) extends Lens S A where
   /-- `get (set s a) = a` -/
   get_set : ∀ s a, get (set s a) = a
@@ -45,7 +56,44 @@ def over (l : Lens S A) (f : A → A) : S → S :=
 def comp (l₁ : Lens S A) (l₂ : Lens A B) : Lens S B :=
   ⟨l₂.get ∘ l₁.get, fun s b => l₁.set s (l₂.set (l₁.get s) b)⟩
 
-instance : Coe (LawfulLens S A) (Lens S A) := ⟨fun l => l.toLens⟩
+infixl:80 " ∘ₗ " => comp
+
+instance : Coe (LawfulLens S A) (Lens S A) := ⟨LawfulLens.toLens⟩
+
+/-- Build a lawful lens from getter, setter, and law proofs. -/
+def mkLawful (get : S → A) (set : S → A → S)
+    (get_set : ∀ s a, get (set s a) = a)
+    (set_get : ∀ s, set s (get s) = s)
+    (set_set : ∀ s a b, set (set s a) b = set s b) : LawfulLens S A :=
+  { get, set, get_set, set_get, set_set }
+
+@[simp] theorem lawful_get_set (l : LawfulLens S A) (s : S) (a : A) :
+    l.get (l.set s a) = a :=
+  l.get_set s a
+
+@[simp] theorem lawful_set_get (l : LawfulLens S A) (s : S) :
+    l.set s (l.get s) = s :=
+  l.set_get s
+
+@[simp] theorem lawful_set_set (l : LawfulLens S A) (s : S) (a b : A) :
+    l.set (l.set s a) b = l.set s b :=
+  l.set_set s a b
+
+/-- Composition preserves lawfulness. -/
+theorem comp_lawful (l₁ : LawfulLens S A) (l₂ : LawfulLens A B) :
+    LawfulLens (comp l₁ l₂) where
+  get_set := by
+    intro s b
+    dsimp [comp]
+    rw [l₁.get_set, l₂.get_set]
+  set_get := by
+    intro s
+    dsimp [comp]
+    rw [l₂.set_get, l₁.set_get]
+  set_set := by
+    intro s a b
+    dsimp [comp]
+    rw [l₁.get_set, l₂.set_set, l₁.set_set]
 
 end Lens
 

--- a/Cslib/Foundations/Data/Lens/Basic.lean
+++ b/Cslib/Foundations/Data/Lens/Basic.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2026 Mateo Petel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mateo Petel
+-/
+
+module
+
+public import Cslib.Init
+
+/-! # Lawful lenses
+
+Minimal lens API for verified access and update of record-shaped state.
+-/
+
+namespace Cslib
+
+universe u
+
+/-- A lens focuses on a component `A` inside a whole state `S`. -/
+structure Lens (S A : Type u) where
+  /-- Read the focused component. -/
+  get : S → A
+  /-- Replace the focused component, leaving the rest of `S` unchanged. -/
+  set : S → A → S
+
+/--
+A `LawfulLens` bundles the standard lens laws stated in `get`/`set` vocabulary.
+-/
+structure LawfulLens (S A : Type u) extends Lens S A where
+  /-- `get (set s a) = a` -/
+  get_set : ∀ s a, get (set s a) = a
+  /-- `set s (get s) = s` -/
+  set_get : ∀ s, set s (get s) = s
+  /-- `set (set s a) b = set s b` -/
+  set_set : ∀ s a b, set (set s a) b = set s b
+
+namespace Lens
+
+/-- Update the focused component with a function. -/
+def over (l : Lens S A) (f : A → A) : S → S :=
+  fun s => l.set s (f (l.get s))
+
+/-- Compose nested lenses: outer `l₁` then inner `l₂`. -/
+def comp (l₁ : Lens S A) (l₂ : Lens A B) : Lens S B :=
+  ⟨l₂.get ∘ l₁.get, fun s b => l₁.set s (l₂.set (l₁.get s) b)⟩
+
+instance : Coe (LawfulLens S A) (Lens S A) := ⟨fun l => l.toLens⟩
+
+end Lens
+
+end Cslib

--- a/Cslib/Foundations/Data/Lens/Basic.lean
+++ b/Cslib/Foundations/Data/Lens/Basic.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2026 Mateo Petel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mateo Petel
+-/
+
+module
+
+public import Cslib.Init
+
+/-!
+# Lawful lenses
+
+A small lens API for verified access and update of structured state.
+
+## Main definitions
+
+- `Lens`: a getter and setter focusing on a component of a larger state.
+- `LawfulLens`: a lens satisfying the standard get-set, set-get, and set-set laws.
+- `Lens.over`: update the focused component with a function.
+- `Lens.comp`: compose nested lenses.
+
+## Main results
+
+- `Lens.compLawful`: composition of lawful lenses is lawful.
+-/
+
+@[expose] public section
+
+namespace Cslib
+
+universe u v w
+
+/-- A lens focuses on a component `A` inside a state `S`. -/
+structure Lens (S : Type u) (A : Type v) where
+  /-- Read the focused component. -/
+  get : S → A
+  /-- Replace the focused component. -/
+  set : S → A → S
+
+/-- A lens bundled with the standard get-set, set-get, and set-set laws. -/
+structure LawfulLens (S : Type u) (A : Type v) extends Lens S A where
+  /-- Reading immediately after writing returns the written value. -/
+  get_set : ∀ s a, get (set s a) = a
+  /-- Writing the value already present leaves the state unchanged. -/
+  set_get : ∀ s, set s (get s) = s
+  /-- Consecutive writes to the same focus retain only the final value. -/
+  set_set : ∀ s a b, set (set s a) b = set s b
+
+attribute [simp] LawfulLens.get_set LawfulLens.set_get LawfulLens.set_set
+
+namespace Lens
+
+variable {S : Type u} {A : Type v} {B : Type w}
+
+/-- Update the focused component with a function. -/
+def over (l : Lens S A) (f : A → A) (s : S) : S :=
+  l.set s (f (l.get s))
+
+/-- Compose nested lenses: first focus from `S` to `A`, then from `A` to `B`. -/
+def comp (l₁ : Lens S A) (l₂ : Lens A B) : Lens S B :=
+  ⟨l₂.get ∘ l₁.get, fun s b => l₁.set s (l₂.set (l₁.get s) b)⟩
+
+@[simp]
+theorem comp_get (l₁ : Lens S A) (l₂ : Lens A B) (s : S) :
+    (comp l₁ l₂).get s = l₂.get (l₁.get s) := rfl
+
+@[simp]
+theorem comp_set (l₁ : Lens S A) (l₂ : Lens A B) (s : S) (b : B) :
+    (comp l₁ l₂).set s b = l₁.set s (l₂.set (l₁.get s) b) := rfl
+
+instance : Coe (LawfulLens S A) (Lens S A) := ⟨LawfulLens.toLens⟩
+
+/-- Composition of lawful lenses is lawful. -/
+def compLawful (l₁ : LawfulLens S A) (l₂ : LawfulLens A B) : LawfulLens S B where
+  get := l₂.get ∘ l₁.get
+  set := fun s b => l₁.set s (l₂.set (l₁.get s) b)
+  get_set := by
+    intro s b
+    simp
+  set_get := by
+    intro s
+    simp
+  set_set := by
+    intro s a b
+    simp
+
+end Lens
+
+end Cslib

--- a/Cslib/Foundations/Data/Lens/Examples/MachineState.lean
+++ b/Cslib/Foundations/Data/Lens/Examples/MachineState.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2026 Mateo Petel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mateo Petel
+-/
+
+module
+
+public import Cslib.Foundations.Data.Lens.Basic
+
+/-! # Machine state example
+
+Lawful lens over program counter and a verified step that preserves memory and halt flag.
+-/
+
+namespace Cslib.Examples
+
+structure MachineState where
+  pc : Nat
+  memory : List Nat
+  halted : Bool
+
+namespace MachineState
+
+def pcLens : LawfulLens MachineState Nat where
+  get := MachineState.pc
+  set := fun s pc => { s with pc := pc }
+  get_set := by intro s pc; rfl
+  set_get := by intro s; rfl
+  set_set := by intro s pc₁ pc₂; rfl
+
+/-- Advance the program counter when the machine has not halted. -/
+def step (s : MachineState) : MachineState :=
+  if s.halted then s else pcLens.over (· + 1) s
+
+theorem step_preserves_memory (s : MachineState) : (step s).memory = s.memory := by
+  rcases s with ⟨pc, memory, hal⟩
+  cases hal <;> dsimp [step, pcLens, Lens.over]
+
+theorem step_preserves_halted (s : MachineState) : (step s).halted = s.halted := by
+  rcases s with ⟨pc, memory, hal⟩
+  cases hal <;> dsimp [step, pcLens, Lens.over]
+
+theorem step_increments_pc (s : MachineState) (h : ¬ s.halted) : (step s).pc = s.pc + 1 := by
+  rcases s with ⟨pc, memory, hal⟩
+  cases hal with
+  | true => simp at h
+  | false => dsimp [step, pcLens, Lens.over]
+
+end MachineState
+
+end Cslib.Examples

--- a/Cslib/Foundations/Data/Lens/Examples/MachineState.lean
+++ b/Cslib/Foundations/Data/Lens/Examples/MachineState.lean
@@ -20,13 +20,18 @@ namespace Cslib.Foundations.Data.Lens.Examples
 
 open Cslib Lens
 
+/-- A minimal interpreter-style machine state. -/
 structure MachineState where
+  /-- Program counter. -/
   pc : Nat
+  /-- Main memory as a list of natural numbers. -/
   memory : List Nat
+  /-- Whether execution has halted. -/
   halted : Bool
 
 namespace MachineState
 
+/-- Lawful lens focusing on the program counter. -/
 def pcLens : LawfulLens MachineState Nat :=
   mkLawful
     (get := MachineState.pc)
@@ -39,14 +44,17 @@ def pcLens : LawfulLens MachineState Nat :=
 def step (s : MachineState) : MachineState :=
   if s.halted then s else over pcLens (· + 1) s
 
+/-- `step` leaves memory unchanged. -/
 theorem step_preserves_memory (s : MachineState) : (step s).memory = s.memory := by
   rcases s with ⟨pc, memory, hal⟩
   cases hal <;> dsimp [step, pcLens, over, mkLawful]
 
+/-- `step` leaves the halt flag unchanged. -/
 theorem step_preserves_halted (s : MachineState) : (step s).halted = s.halted := by
   rcases s with ⟨pc, memory, hal⟩
   cases hal <;> dsimp [step, pcLens, over, mkLawful]
 
+/-- When not halted, `step` increments the program counter by one. -/
 theorem step_increments_pc (s : MachineState) (h : ¬ s.halted) : (step s).pc = s.pc + 1 := by
   rcases s with ⟨pc, memory, hal⟩
   cases hal with

--- a/Cslib/Foundations/Data/Lens/Examples/MachineState.lean
+++ b/Cslib/Foundations/Data/Lens/Examples/MachineState.lean
@@ -8,12 +8,17 @@ module
 
 public import Cslib.Foundations.Data.Lens.Basic
 
-/-! # Machine state example
+/-!
+# Machine state example
 
-Lawful lens over program counter and a verified step that preserves memory and halt flag.
+Lawful lens over the program counter and a verified step that preserves memory and the halt flag.
 -/
 
-namespace Cslib.Examples
+@[expose] public section
+
+namespace Cslib.Foundations.Data.Lens.Examples
+
+open Cslib Lens
 
 structure MachineState where
   pc : Nat
@@ -22,31 +27,32 @@ structure MachineState where
 
 namespace MachineState
 
-def pcLens : LawfulLens MachineState Nat where
-  get := MachineState.pc
-  set := fun s pc => { s with pc := pc }
-  get_set := by intro s pc; rfl
-  set_get := by intro s; rfl
-  set_set := by intro s pc₁ pc₂; rfl
+def pcLens : LawfulLens MachineState Nat :=
+  mkLawful
+    (get := MachineState.pc)
+    (set := fun s pc => { s with pc := pc })
+    (get_set := by intro s pc; rfl)
+    (set_get := by intro s; rfl)
+    (set_set := by intro s pc₁ pc₂; rfl)
 
 /-- Advance the program counter when the machine has not halted. -/
 def step (s : MachineState) : MachineState :=
-  if s.halted then s else pcLens.over (· + 1) s
+  if s.halted then s else over pcLens (· + 1) s
 
 theorem step_preserves_memory (s : MachineState) : (step s).memory = s.memory := by
   rcases s with ⟨pc, memory, hal⟩
-  cases hal <;> dsimp [step, pcLens, Lens.over]
+  cases hal <;> dsimp [step, pcLens, over, mkLawful]
 
 theorem step_preserves_halted (s : MachineState) : (step s).halted = s.halted := by
   rcases s with ⟨pc, memory, hal⟩
-  cases hal <;> dsimp [step, pcLens, Lens.over]
+  cases hal <;> dsimp [step, pcLens, over, mkLawful]
 
 theorem step_increments_pc (s : MachineState) (h : ¬ s.halted) : (step s).pc = s.pc + 1 := by
   rcases s with ⟨pc, memory, hal⟩
   cases hal with
   | true => simp at h
-  | false => dsimp [step, pcLens, Lens.over]
+  | false => dsimp [step, pcLens, over, mkLawful]
 
 end MachineState
 
-end Cslib.Examples
+end Cslib.Foundations.Data.Lens.Examples

--- a/CslibTests.lean
+++ b/CslibTests.lean
@@ -14,6 +14,7 @@ import CslibTests.ImportWithMathlib
 import CslibTests.InferenceSystem
 import CslibTests.LTS
 import CslibTests.LambdaCalculus
+import CslibTests.Lens
 import CslibTests.MLL
 import CslibTests.Modal
 import CslibTests.Modal.Ideal

--- a/CslibTests/Lens.lean
+++ b/CslibTests/Lens.lean
@@ -1,0 +1,39 @@
+import Cslib.Computability.URM.Defs
+import Cslib.Foundations.Data.Lens.Basic
+
+namespace CslibTests.Lens
+
+open Cslib
+open Cslib.URM
+
+/-- A lawful lens for the program counter of CSLib's existing URM state. -/
+def pcLens : LawfulLens State Nat where
+  get := State.pc
+  set := fun s pc => { s with pc := pc }
+  get_set := by
+    intro s pc
+    rfl
+  set_get := by
+    intro s
+    cases s
+    rfl
+  set_set := by
+    intro s pc₁ pc₂
+    cases s
+    rfl
+
+/-- Increment the program counter through the lens API. -/
+def bumpPC (s : State) : State :=
+  Cslib.Lens.over pcLens (· + 1) s
+
+@[simp]
+theorem bumpPC_pc (s : State) : (bumpPC s).pc = s.pc + 1 := by
+  cases s
+  rfl
+
+@[simp]
+theorem bumpPC_regs (s : State) : (bumpPC s).regs = s.regs := by
+  cases s
+  rfl
+
+end CslibTests.Lens

--- a/CslibTests/Lens.lean
+++ b/CslibTests/Lens.lean
@@ -1,3 +1,9 @@
+/-
+Copyright (c) 2026 Mateo Petel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mateo Petel
+-/
+
 import Cslib.Computability.URM.Defs
 import Cslib.Foundations.Data.Lens.Basic
 


### PR DESCRIPTION
## Summary

Draft PR for discussion in #658.

Adds a deliberately small lawful-lens core for verified state access:

- universe-polymorphic `Lens S A` with `get` and `set`
- `LawfulLens S A` with the standard `get_set`, `set_get`, and `set_set` laws
- `Lens.over` and nested lens composition via `Lens.comp`
- `Lens.compLawful`, showing that composition preserves the laws
- a test using CSLib's existing `URM.State` rather than introducing a new production example type

The example-only production module from the original draft has been removed; the root `Cslib` import exposes only the foundational lens module.

## Motivation

Verified CS developments repeatedly manipulate structured machine/interpreter state and then prove that focused updates preserve unrelated fields. This PR proposes only the reusable getter/setter abstraction and its algebraic laws, with a test demonstrating the pattern on an existing CSLib machine state.

## Explicitly out of scope

- prisms and traversals
- profunctor optics
- derivation macros or tactic automation
- telemetry or benchmarks
- a new machine-state abstraction

## Validation

The branch is rebuilt directly on current `main` (`492d030f13f42202bb3e01d67816095487d90493`) with a four-file diff. Current-head CI is green on `c49b4e67f034b342a42da5d19f30ee1cb183d313`.

- [x] `lake build --wfail --iofail`
- [x] `lake test --wfail --iofail`
- [x] `lake lint`
- [x] `lake exe mk_all --check`
- [x] `lake exe checkInitImports`
- [x] repository style, case-sensitivity, and ignored-file checks
- [x] PR title convention check

The PR remains draft because the remaining question is API/design acceptance, not build status.

## AI disclosure

This draft and subsequent refactoring were prepared with assistance from an AI coding tool. The proposed API is based on extraction work in `fraware/lean-optics`; the contributor is responsible for reviewing and understanding the declarations, proofs, and design before requesting final review.