### PR TITLE
feat(Data/PFunctor): extend free monad and M-type APIs

### DIFF
--- a/Cslib.lean
+++ b/Cslib.lean
@@ -73,6 +73,7 @@ public import Cslib.Foundations.Data.OmegaSequence.InfOcc
 public import Cslib.Foundations.Data.OmegaSequence.Init
 public import Cslib.Foundations.Data.OmegaSequence.Temporal
 public import Cslib.Foundations.Data.PFunctor.Free
+public import Cslib.Foundations.Data.PFunctor.M
 public import Cslib.Foundations.Data.RelatesInSteps
 public import Cslib.Foundations.Data.Set.Saturation
 public import Cslib.Foundations.Data.StackTape

--- a/Cslib/Foundations/Data/PFunctor/Free.lean
+++ b/Cslib/Foundations/Data/PFunctor/Free.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Quang Dao. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Quang Dao, Devon Tuma
 -/
 
 module
@@ -61,6 +61,7 @@ This construction is ported from the [VCV-io](https://github.com/dtumad/VCV-io) 
 - `PFunctor.FreeM.lift`: Lift a shape of the base polynomial functor into the free monad.
 - `PFunctor.FreeM.liftObj`: Lift an object of the base polynomial functor into the free monad.
 - `PFunctor.FreeM.liftM`: Interpret `FreeM P` into any other monad.
+- `PFunctor.FreeM.equivWOfIsEmpty`: Identify `FreeM P α` with `P.W` when `α` is empty.
 -/
 
 @[expose] public section
@@ -185,6 +186,14 @@ lemma bind_pure_comp (f : α → β) : ∀ x : P.FreeM α, x.bind (pure ∘ f) =
   | .liftBind a cont => by simp only [FreeM.bind, map, bind_pure_comp]
 
 @[simp]
+theorem map_pure (f : α → β) (x : α) : map f (pure x : P.FreeM α) = pure (f x) := rfl
+
+@[simp]
+theorem map_bind (f : β → γ) (x : P.FreeM α) (cont : α → P.FreeM β) :
+    map f (x.bind cont) = x.bind fun a => (cont a).map f := by
+  simp_rw [← bind_pure_comp, FreeM.bind_assoc]
+
+@[simp]
 lemma liftBind_bind (a : P.A) (cont : P.B a → P.FreeM β) (f : β → P.FreeM γ) :
     ((FreeM.lift a).bind cont).bind f = (FreeM.lift a).bind (fun u ↦ (cont u).bind f) := by
   simp only [lift]
@@ -259,6 +268,30 @@ lemma liftBind_inj (a a' : P.A)
     exact ⟨rfl, rfl⟩
   · rintro ⟨rfl, rfl⟩
     rfl
+
+/-- Convert a leafless free polynomial tree to a W-type tree. -/
+def toW [IsEmpty α] : P.FreeM α → P.W
+  | .pure y => (IsEmpty.false y).elim
+  | .liftBind a cont => ⟨a, fun b => toW (cont b)⟩
+
+/-- Convert a W-type tree to a leafless free polynomial tree. -/
+def ofW [IsEmpty α] : P.W → P.FreeM α
+  | ⟨a, f⟩ => FreeM.liftBind a fun b => ofW (f b)
+
+@[simp] lemma ofW_toW [IsEmpty α] (x : P.FreeM α) : ofW (toW x) = x := by
+  induction x with
+  | pure y => exact (IsEmpty.false y).elim
+  | lift_bind a cont ih => exact congrArg (FreeM.liftBind a) (funext ih)
+
+@[simp] lemma toW_ofW [IsEmpty α] (w : P.W) : toW (ofW (α := α) w) = w := by
+  induction w with | mk a f ih => exact congrArg (WType.mk a) (funext ih)
+
+/-- When the value type is empty, `FreeM P α` is equivalent to the W-type `P.W`. -/
+def equivWOfIsEmpty [IsEmpty α] : P.FreeM α ≃ P.W where
+  toFun := toW
+  invFun := ofW
+  left_inv := ofW_toW
+  right_inv := toW_ofW
 
 section liftM
 
@@ -369,6 +402,11 @@ lemma liftM_lift (interp : (a : P.A) → m (P.B a)) (a : P.A) :
 lemma liftM_liftObj (interp : (a : P.A) → m (P.B a)) (x : P.Obj α) :
     (FreeM.liftObj x).liftM interp = x.2 <$> interp x.1 := by
   simp [liftObj]
+
+/-- Folding a free polynomial tree by lifting each operation back into `FreeM` is the identity. -/
+@[simp]
+theorem liftM_lift_eq_self (x : P.FreeM α) : FreeM.liftM FreeM.lift x = x := by
+  induction x with | pure _ => simp | lift_bind _ _ ih => simp [ih]
 
 end liftM
 

--- a/Cslib/Foundations/Data/PFunctor/M.lean
+++ b/Cslib/Foundations/Data/PFunctor/M.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma, Quang Dao
+-/
+
+module
+
+public import Cslib.Init
+public import Mathlib.Data.PFunctor.Univariate.M
+
+/-!
+# Auxiliary Lemmas for `PFunctor.M`
+
+This file extends the M-type API with rewriting and coinduction helpers for reasoning about
+potentially infinite polynomial trees.
+
+## Main Definitions
+
+- `PFunctor.M.eq_of_dest_eq`: Extensionality through the M-type destructor.
+- `PFunctor.M.dest_corec_apply`: An explicit destructor equation for `M.corec`.
+- `PFunctor.M.corec_eq_corec`: A relational coinduction principle for two corecursive definitions.
+- `PFunctor.M.corec_dest`: The corecursive identity.
+-/
+
+@[expose] public section
+
+universe uA uB v w
+
+namespace PFunctor.M
+
+variable {P : PFunctor.{uA, uB}} {α : Type v}
+
+/-- `M.dest` is injective because `M.mk` is its left inverse. -/
+theorem eq_of_dest_eq {u v : M P} (h : M.dest u = M.dest v) : u = v := by
+  rw [← M.mk_dest u, ← M.mk_dest v, h]
+
+@[simp]
+theorem dest_inj {u v : M P} : M.dest u = M.dest v ↔ u = v :=
+  ⟨eq_of_dest_eq, fun h => h ▸ rfl⟩
+
+/-- `M.dest_corec` with the resulting sigma type unpacked. -/
+theorem dest_corec_apply (g : α → P α) (x : α) :
+    M.dest (M.corec g x) = ⟨(g x).1, fun b => M.corec g ((g x).2 b)⟩ := rfl
+
+/-- An explicit form of `dest_corec_apply` when the corecursive step is known. -/
+theorem dest_corec_eq {a : P.A} {h : P.B a → α} (g : α → P α) (x : α)
+    (heq : g x = ⟨a, h⟩) : M.dest (M.corec g x) = ⟨a, fun b => M.corec g (h b)⟩ := by
+  rw [dest_corec_apply, heq]
+
+/-- A relational coinduction principle for two `M.corec` constructions. -/
+theorem corec_eq_corec {α : Type v} {β : Type w} (g : α → P α) (h : β → P β)
+    (R : α → β → Prop) (x₀ : α) (y₀ : β) (hR : R x₀ y₀)
+    (step : ∀ x y, R x y → ∃ a f f',
+      g x = ⟨a, f⟩ ∧ h y = ⟨a, f'⟩ ∧ ∀ i, R (f i) (f' i)) :
+    M.corec g x₀ = M.corec h y₀ := by
+  let S : M P → M P → Prop := fun u v => ∃ x y, R x y ∧ u = M.corec g x ∧ v = M.corec h y
+  refine M.bisim S ?_ _ _ ⟨x₀, y₀, hR, rfl, rfl⟩
+  rintro u v ⟨x, y, hxy, rfl, rfl⟩
+  obtain ⟨a, f, f', hf, hf', hR'⟩ := step x y hxy
+  refine ⟨a, M.corec g ∘ f, M.corec h ∘ f', ?_, ?_, ?_⟩
+  · simp [dest_corec, hf]
+  · simp [dest_corec, hf']
+  · exact fun i => ⟨f i, f' i, hR' i, rfl, rfl⟩
+
+/-- Corecursing with `M.dest` returns the original M-type value. -/
+theorem corec_dest (u : M P) : M.corec M.dest u = u := by
+  refine M.bisim (fun a b => a = M.corec M.dest b) ?_ _ _ rfl
+  rintro a b rfl
+  exact ⟨(M.dest b).1, (fun i => M.corec M.dest ((M.dest b).2 i)),
+    (M.dest b).2, by rw [dest_corec_apply], rfl, fun _ => rfl⟩
+
+end PFunctor.M


### PR DESCRIPTION
## Summary

Add several basic results for polynomial free monads and M-types. These mostly come from downstream [PolyFun](https://github.com/Verified-zkEVM/PolyFun) library.

  For `PFunctor.FreeM`:

  - prove `map_pure` and `map_bind` for the universe-polymorphic `FreeM.map`;
  - identify leafless free trees with W-types via `equivWOfIsEmpty`;
  - add simp lemmas for both directions of this equivalence;
  - prove that interpreting every operation with `FreeM.lift` is the identity.

  For `PFunctor.M`:

  - add injectivity of `M.dest`;
  - provide explicit rewriting lemmas for `M.dest (M.corec ...)`;
  - add a relational coinduction principle for comparing two corecursive definitions;
  - prove the identity `M.corec M.dest u = u`.

  These results are useful when treating `FreeM` and `M` as the initial and final fixed points associated with a polynomial functor.