### PR TITLE
feat(confluence): add relation-level reduction inclusions

### DIFF
--- a/Cslib/Languages/CombinatoryLogic/Confluence.lean
+++ b/Cslib/Languages/CombinatoryLogic/Confluence.lean
@@ -59,45 +59,51 @@ inductive ParallelReduction : SKI → SKI → Prop
   | par ⦃a a' b b' : SKI⦄ :
       ParallelReduction a a' → ParallelReduction b b' → ParallelReduction (a ⬝ b) (a' ⬝ b')
 
-/-- The inclusion `⭢ₚ ⊆ ↠` -/
-theorem mRed_of_parallelReduction {a a' : SKI} (h : a ⭢ₚ a') : a ↠ a' := by
+/-- The inclusion `(· ⭢ₚ ·) ≤ (· ↠ ·)`. -/
+theorem parallelReduction_le_reflTransGen_red :
+    (· ⭢ₚ ·) ≤ (· ↠ ·) := by
+  intro a a' h
   cases h
   case refl => exact Relation.ReflTransGen.refl
   case par a a' b b' ha hb =>
     apply parallel_mRed
-    · exact mRed_of_parallelReduction ha
-    · exact mRed_of_parallelReduction hb
+    · exact parallelReduction_le_reflTransGen_red _ _ ha
+    · exact parallelReduction_le_reflTransGen_red _ _ hb
   case red_I => exact Relation.ReflTransGen.single (red_I a')
   case red_K b => exact Relation.ReflTransGen.single (red_K a' b)
   case red_S a b c => exact Relation.ReflTransGen.single (red_S a b c)
 
-/-- The inclusion `⭢ ⊆ ⭢ₚ` -/
-theorem parallelReduction_of_red {a a' : SKI} (h : a ⭢ a') : a ⭢ₚ a' := by
+/-- Pointwise form of `parallelReduction_le_reflTransGen_red`. -/
+theorem mRed_of_parallelReduction {a a' : SKI} (h : a ⭢ₚ a') : a ↠ a' :=
+  parallelReduction_le_reflTransGen_red a a' h
+
+/-- The inclusion `(· ⭢ ·) ≤ (· ⭢ₚ ·)`. -/
+theorem red_le_parallelReduction :
+    (· ⭢ ·) ≤ (· ⭢ₚ ·) := by
+  intro a a' h
   cases h
   case red_S => apply ParallelReduction.red_S
   case red_K => apply ParallelReduction.red_K
   case red_I => apply ParallelReduction.red_I
   case red_head a a' b h =>
     apply ParallelReduction.par
-    · exact parallelReduction_of_red h
+    · exact red_le_parallelReduction _ _ h
     · exact ParallelReduction.refl b
   case red_tail a b b' h =>
     apply ParallelReduction.par
     · exact ParallelReduction.refl a
-    · exact parallelReduction_of_red h
+    · exact red_le_parallelReduction _ _ h
 
-/-- The inclusions of `mRed_of_parallelReduction` and
-`parallelReduction_of_red` imply that `⭢` and `⭢ₚ` have the same reflexive-transitive
-closure. -/
+/-- Pointwise form of `red_le_parallelReduction`. -/
+theorem parallelReduction_of_red {a a' : SKI} (h : a ⭢ a') : a ⭢ₚ a' :=
+  red_le_parallelReduction a a' h
+
+/-- The relations `⭢` and `⭢ₚ` have the same reflexive-transitive closure. -/
 theorem reflTransGen_parallelReduction_mRed :
     ReflTransGen ParallelReduction = ReflTransGen Red := by
-  ext a b
-  constructor
-  · apply reflTransGen_le_of_le
-    -- TODO: restate `parallelReduction_of_red` and others using `≤`?
-    exact @mRed_of_parallelReduction
-  · apply Relation.reflTransGen_le_of_le
-    exact fun a a' h => Relation.ReflTransGen.single (parallelReduction_of_red h)
+  apply le_antisymm
+  · exact reflTransGen_le_of_le parallelReduction_le_reflTransGen_red
+  · exact ReflTransGen.mono red_le_parallelReduction
 
 /-!
 Irreducibility for the (partially applied) primitive combinators.

--- a/Cslib/Languages/CombinatoryLogic/Confluence.lean
+++ b/Cslib/Languages/CombinatoryLogic/Confluence.lean
@@ -60,25 +60,21 @@ inductive ParallelReduction : SKI → SKI → Prop
       ParallelReduction a a' → ParallelReduction b b' → ParallelReduction (a ⬝ b) (a' ⬝ b')
 
 /-- The inclusion `(· ⭢ₚ ·) ≤ (· ↠ ·)`. -/
-theorem parallelReduction_le_reflTransGen_red :
+theorem ParallelReduction.le_reflTransGen_red :
     (· ⭢ₚ ·) ≤ (· ↠ ·) := by
   intro a a' h
   cases h
   case refl => exact Relation.ReflTransGen.refl
   case par a a' b b' ha hb =>
     apply parallel_mRed
-    · exact parallelReduction_le_reflTransGen_red _ _ ha
-    · exact parallelReduction_le_reflTransGen_red _ _ hb
-  case red_I => exact Relation.ReflTransGen.single (red_I a')
-  case red_K b => exact Relation.ReflTransGen.single (red_K a' b)
-  case red_S a b c => exact Relation.ReflTransGen.single (red_S a b c)
-
-/-- Pointwise form of `parallelReduction_le_reflTransGen_red`. -/
-theorem mRed_of_parallelReduction {a a' : SKI} (h : a ⭢ₚ a') : a ↠ a' :=
-  parallelReduction_le_reflTransGen_red a a' h
+    · exact ha.le_reflTransGen_red
+    · exact hb.le_reflTransGen_red
+  case red_I => exact Relation.ReflTransGen.single (Red.red_I a')
+  case red_K b => exact Relation.ReflTransGen.single (Red.red_K a' b)
+  case red_S a b c => exact Relation.ReflTransGen.single (Red.red_S a b c)
 
 /-- The inclusion `(· ⭢ ·) ≤ (· ⭢ₚ ·)`. -/
-theorem red_le_parallelReduction :
+theorem Red.le_parallelReduction :
     (· ⭢ ·) ≤ (· ⭢ₚ ·) := by
   intro a a' h
   cases h
@@ -87,23 +83,19 @@ theorem red_le_parallelReduction :
   case red_I => apply ParallelReduction.red_I
   case red_head a a' b h =>
     apply ParallelReduction.par
-    · exact red_le_parallelReduction _ _ h
+    · exact h.le_parallelReduction
     · exact ParallelReduction.refl b
   case red_tail a b b' h =>
     apply ParallelReduction.par
     · exact ParallelReduction.refl a
-    · exact red_le_parallelReduction _ _ h
-
-/-- Pointwise form of `red_le_parallelReduction`. -/
-theorem parallelReduction_of_red {a a' : SKI} (h : a ⭢ a') : a ⭢ₚ a' :=
-  red_le_parallelReduction a a' h
+    · exact h.le_parallelReduction
 
 /-- The relations `⭢` and `⭢ₚ` have the same reflexive-transitive closure. -/
 theorem reflTransGen_parallelReduction_mRed :
     ReflTransGen ParallelReduction = ReflTransGen Red := by
   apply le_antisymm
-  · exact reflTransGen_le_of_le parallelReduction_le_reflTransGen_red
-  · exact ReflTransGen.mono red_le_parallelReduction
+  · exact reflTransGen_le_of_le ParallelReduction.le_reflTransGen_red
+  · exact ReflTransGen.mono Red.le_parallelReduction
 
 /-!
 Irreducibility for the (partially applied) primitive combinators.

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullBetaConfluence.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullBetaConfluence.lean
@@ -73,8 +73,10 @@ lemma para_lc_r (step : M ⭢ₚ N) : LC N := by
   all_goals grind
 
 omit [HasFresh Var] [DecidableEq Var] in
-/-- A single β-reduction implies a single parallel reduction. -/
-lemma step_to_para (step : M ⭢βᶠ N) : M ⭢ₚ N := by
+/-- The inclusion `(· ⭢βᶠ ·) ≤ (· ⭢ₚ ·)`. -/
+lemma fullBeta_le_parallel :
+    ((· ⭢βᶠ ·) : Term Var → Term Var → Prop) ≤ (· ⭢ₚ ·) := by
+  intro M N step
   induction step with
   | base h =>
     cases h with | beta abs_lc _ =>
@@ -83,9 +85,16 @@ lemma step_to_para (step : M ⭢βᶠ N) : M ⭢ₚ N := by
   | abs xs _ _ => apply Parallel.abs xs; grind
   | _ => grind
 
+omit [HasFresh Var] [DecidableEq Var] in
+/-- Pointwise form of `fullBeta_le_parallel`. -/
+lemma step_to_para (step : M ⭢βᶠ N) : M ⭢ₚ N :=
+  fullBeta_le_parallel M N step
+
 open FullBeta in
-/-- A single parallel reduction implies a multiple β-reduction. -/
-lemma para_to_redex (para : M ⭢ₚ N) : M ↠βᶠ N := by
+/-- The inclusion `(· ⭢ₚ ·) ≤ (· ↠βᶠ ·)`. -/
+lemma parallel_le_reflTransGen_fullBeta :
+    ((· ⭢ₚ ·) : Term Var → Term Var → Prop) ≤ (· ↠βᶠ ·) := by
+  intro M N para
   induction para
   case fvar => constructor
   case app L L' R R' l_para m_para redex_l redex_m =>
@@ -105,11 +114,14 @@ lemma para_to_redex (para : M ⭢ₚ N) : M ↠βᶠ N := by
       _           ↠βᶠ m'.abs.app n' := by grind
       _           ⭢βᶠ m' ^ n'       := by grind
 
+/-- Pointwise form of `parallel_le_reflTransGen_fullBeta`. -/
+lemma para_to_redex (para : M ⭢ₚ N) : M ↠βᶠ N :=
+  parallel_le_reflTransGen_fullBeta M N para
+
 /-- Multiple parallel reduction is equivalent to multiple β-reduction. -/
-theorem parachain_iff_redex : M ↠ₚ N ↔ M ↠βᶠ N := by
-  refine Iff.intro ?chain_redex ?redex_chain <;> intros h <;> induction h <;> try rfl
-  case redex_chain redex chain => exact ReflTransGen.tail chain (step_to_para redex)
-  case chain_redex para  redex => exact ReflTransGen.trans redex (para_to_redex para)
+theorem parachain_iff_redex : M ↠ₚ N ↔ M ↠βᶠ N :=
+  ⟨reflTransGen_le_of_le parallel_le_reflTransGen_fullBeta M N,
+    ReflTransGen.mono fullBeta_le_parallel M N⟩
 
 /-- Parallel reduction respects substitution. -/
 @[scoped grind .]

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullBetaConfluence.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullBetaConfluence.lean
@@ -109,10 +109,12 @@ lemma Parallel.le_reflTransGen_fullBeta :
       _           ↠βᶠ m'.abs.app n' := by grind
       _           ⭢βᶠ m' ^ n'       := by grind
 
-/-- Multiple parallel reduction is equivalent to multiple β-reduction. -/
-theorem parachain_iff_redex : M ↠ₚ N ↔ M ↠βᶠ N :=
-  ⟨reflTransGen_le_of_le Parallel.le_reflTransGen_fullBeta M N,
-    ReflTransGen.mono FullBeta.le_parallel M N⟩
+/-- Multiple parallel reduction is equal to multiple β-reduction. -/
+theorem reflTransGen_parallel_fullBeta :
+    ((· ↠ₚ ·) : Term Var → Term Var → Prop) = (· ↠βᶠ ·) := by
+  apply le_antisymm
+  · exact reflTransGen_le_of_le Parallel.le_reflTransGen_fullBeta
+  · exact ReflTransGen.mono FullBeta.le_parallel
 
 /-- Parallel reduction respects substitution. -/
 @[scoped grind .]
@@ -208,10 +210,9 @@ theorem para_confluence : Confluent (@Parallel Var) :=
 /-- β-reduction is confluent. -/
 @[wikidata Q1308502]
 theorem confluence_beta : Confluent (@FullBeta Var) := by
-  have eq : ReflTransGen (@Parallel Var) = ReflTransGen (@FullBeta Var) := by
-    ext
-    exact parachain_iff_redex
-  rw [Confluent, ←eq]
+  rw [Confluent]
+  change Diamond ((· ↠βᶠ ·) : Term Var → Term Var → Prop)
+  rw [←reflTransGen_parallel_fullBeta]
   exact para_confluence
 
 end LambdaCalculus.LocallyNameless.Untyped.Term

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullBetaConfluence.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullBetaConfluence.lean
@@ -74,7 +74,7 @@ lemma para_lc_r (step : M ⭢ₚ N) : LC N := by
 
 omit [HasFresh Var] [DecidableEq Var] in
 /-- The inclusion `(· ⭢βᶠ ·) ≤ (· ⭢ₚ ·)`. -/
-lemma fullBeta_le_parallel :
+lemma FullBeta.le_parallel :
     ((· ⭢βᶠ ·) : Term Var → Term Var → Prop) ≤ (· ⭢ₚ ·) := by
   intro M N step
   induction step with
@@ -85,14 +85,9 @@ lemma fullBeta_le_parallel :
   | abs xs _ _ => apply Parallel.abs xs; grind
   | _ => grind
 
-omit [HasFresh Var] [DecidableEq Var] in
-/-- Pointwise form of `fullBeta_le_parallel`. -/
-lemma step_to_para (step : M ⭢βᶠ N) : M ⭢ₚ N :=
-  fullBeta_le_parallel M N step
-
 open FullBeta in
 /-- The inclusion `(· ⭢ₚ ·) ≤ (· ↠βᶠ ·)`. -/
-lemma parallel_le_reflTransGen_fullBeta :
+lemma Parallel.le_reflTransGen_fullBeta :
     ((· ⭢ₚ ·) : Term Var → Term Var → Prop) ≤ (· ↠βᶠ ·) := by
   intro M N para
   induction para
@@ -114,14 +109,10 @@ lemma parallel_le_reflTransGen_fullBeta :
       _           ↠βᶠ m'.abs.app n' := by grind
       _           ⭢βᶠ m' ^ n'       := by grind
 
-/-- Pointwise form of `parallel_le_reflTransGen_fullBeta`. -/
-lemma para_to_redex (para : M ⭢ₚ N) : M ↠βᶠ N :=
-  parallel_le_reflTransGen_fullBeta M N para
-
 /-- Multiple parallel reduction is equivalent to multiple β-reduction. -/
 theorem parachain_iff_redex : M ↠ₚ N ↔ M ↠βᶠ N :=
-  ⟨reflTransGen_le_of_le parallel_le_reflTransGen_fullBeta M N,
-    ReflTransGen.mono fullBeta_le_parallel M N⟩
+  ⟨reflTransGen_le_of_le Parallel.le_reflTransGen_fullBeta M N,
+    ReflTransGen.mono FullBeta.le_parallel M N⟩
 
 /-- Parallel reduction respects substitution. -/
 @[scoped grind .]

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullBetaConfluence.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullBetaConfluence.lean
@@ -141,7 +141,7 @@ lemma para_open_out (L : Finset Var) (mem : ∀ x, x ∉ L → (M ^ fvar x) ⭢�
 
 -- adapted from https://github.com/ElifUskuplu/Stlc_deBruijn/blob/main/Stlc/confluence.lean
 /-- Parallel reduction has the diamond property. -/
-theorem para_diamond : Diamond (@Parallel Var) := by
+theorem parallel_diamond : Diamond ((· ⭢ₚ ·) : Term Var → Term Var → Prop) := by
   intros t t1 t2 tpt1
   revert t2
   induction tpt1 <;> intros t2 tpt2
@@ -204,16 +204,15 @@ theorem para_diamond : Diamond (@Parallel Var) := by
           apply Parallel.beta (free_union Var) <;> grind
 
 /-- Parallel reduction is confluent. -/
-theorem para_confluence : Confluent (@Parallel Var) :=
-  para_diamond.toConfluent
+theorem confluent_parallel : Confluent ((· ⭢ₚ ·) : Term Var → Term Var → Prop) :=
+  parallel_diamond.toConfluent
 
 /-- β-reduction is confluent. -/
 @[wikidata Q1308502]
-theorem confluence_beta : Confluent (@FullBeta Var) := by
-  rw [Confluent]
+theorem confluent_fullBeta : Confluent ((· ⭢βᶠ ·) : Term Var → Term Var → Prop) := by
   change Diamond ((· ↠βᶠ ·) : Term Var → Term Var → Prop)
-  rw [←reflTransGen_parallel_fullBeta]
-  exact para_confluence
+  rw [← reflTransGen_parallel_fullBeta]
+  exact confluent_parallel
 
 end LambdaCalculus.LocallyNameless.Untyped.Term
 

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullBetaEtaConfluence.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullBetaEtaConfluence.lean
@@ -95,7 +95,7 @@ open Commute in
 @[wikidata Q1308502]
 theorem confluent_beta_eta : Confluent (@FullBetaEta Var) := by
   apply join_confluent
-  · exact confluence_beta
+  · exact confluent_fullBeta
   · exact stronglyConfluent_eta.toConfluent
   apply symm
   exact stronglyCommute_eta_beta.toCommute


### PR DESCRIPTION
Restates four reduction inclusions as namespaced relation inequalities. Pointwise use remains available through dot notation without duplicate wrapper theorems.

This intentionally removes the old pointwise theorem names; there were no in-repository callers.

Closes #696.

[Zulip chat](https://leanprover.zulipchat.com/#narrow/channel/513188-CSLib/topic/Scope.20of.20issue.20.23696/with/609971277)

Codex was used for part of the code, I have reviewed all the changes done by it.