### PR TITLE
feat(StackTape): lemmas for mapSome

### DIFF
--- a/Cslib/Foundations/Data/StackTape.lean
+++ b/Cslib/Foundations/Data/StackTape.lean
@@ -167,6 +167,10 @@ lemma cons_head?_mapSome (l : List Symbol) :
 @[scoped grind =]
 lemma mapSome_nil : mapSome ([] : List Symbol) = nil := rfl
 
+@[simp, scoped grind =]
+lemma mapSome_eq_nil_iff (l : List Symbol) : mapSome l = nil ↔ l = [] := by
+  cases l <;> simp [mapSome, nil]
+
 end MapSome
 
 section Length

--- a/Cslib/Foundations/Data/StackTape.lean
+++ b/Cslib/Foundations/Data/StackTape.lean
@@ -86,6 +86,9 @@ def cons (x : Option Symbol) (xs : StackTape Symbol) : StackTape Symbol :=
 @[simp, scoped grind =]
 lemma cons_none_nil : cons none (nil : StackTape Symbol) = nil := rfl
 
+lemma cons_none_nil_toList : (cons none (nil : StackTape Symbol)).toList = [] := by
+  simp
+
 @[simp]
 lemma cons_some_toList (a : Symbol) (l : StackTape Symbol) :
     (cons (some a) l).toList = some a :: l.toList := by simp only [cons]
@@ -141,10 +144,10 @@ section MapSome
 /-- Create a `StackTape` from a list by mapping all elements to `some` -/
 def mapSome (l : List Symbol) : StackTape Symbol := ⟨l.map some, by simp⟩
 
-@[scoped grind =]
+@[simp, scoped grind =]
 lemma toList_mapSome (l : List Symbol) : (mapSome l).toList = l.map some := rfl
 
-@[scoped grind =]
+@[simp, scoped grind =]
 lemma head_mapSome (l : List Symbol) : (mapSome l).head = l.head? := by
   cases l <;> rfl
 
@@ -156,7 +159,7 @@ lemma tail_mapSome (l : List Symbol) : (mapSome l).tail = mapSome l.tail := by
 lemma mapSome_cons (a : Symbol) (l : List Symbol) :
     mapSome (a :: l) = cons (some a) (mapSome l) := rfl
 
-@[scoped grind =]
+@[simp, scoped grind =]
 lemma cons_head?_mapSome (l : List Symbol) :
     cons l.head? (mapSome l.tail) = mapSome l := by
   cases l <;> rfl

--- a/Cslib/Foundations/Data/StackTape.lean
+++ b/Cslib/Foundations/Data/StackTape.lean
@@ -151,7 +151,6 @@ lemma mapSome_head (l : List Symbol) : (mapSome l).head = l.head? := by
 lemma mapSome_tail (l : List Symbol) : (mapSome l).tail = mapSome l.tail := by
   cases l <;> rfl
 
-@[simp]
 lemma cons_some_mapSome (a : Symbol) (l : List Symbol) :
     cons (some a) (mapSome l) = mapSome (a :: l) := rfl
 

--- a/Cslib/Foundations/Data/StackTape.lean
+++ b/Cslib/Foundations/Data/StackTape.lean
@@ -160,7 +160,7 @@ lemma cons_head?_mapSome (l : List Symbol) :
   cases l <;> rfl
 
 @[simp]
-lemma mapSome_nil : mapSome ([] : List Symbol) = ∅ := rfl
+lemma mapSome_nil : mapSome ([] : List Symbol) = nil := rfl
 
 end mapSome
 

--- a/Cslib/Foundations/Data/StackTape.lean
+++ b/Cslib/Foundations/Data/StackTape.lean
@@ -141,6 +141,35 @@ lemma cons_head_tail (l : StackTape Symbol) :
 @[scoped grind]
 def mapSome (l : List Symbol) : StackTape Symbol := ⟨l.map some, by simp⟩
 
+@[simp]
+lemma mapSome_head (l : List Symbol) : (mapSome l).head = l.head? := by
+  cases l <;> rfl
+
+@[simp]
+lemma mapSome_tail (l : List Symbol) : (mapSome l).tail = mapSome l.tail := by
+  cases l <;> rfl
+
+@[simp]
+lemma cons_some_mapSome (a : Symbol) (l : List Symbol) :
+    cons (some a) (mapSome l) = mapSome (a :: l) := rfl
+
+@[simp]
+lemma cons_head?_mapSome (l : List Symbol) :
+    cons l.head? (mapSome l.tail) = mapSome l := by
+  cases l <;> rfl
+
+@[simp]
+lemma cons_none_empty : cons none (∅ : StackTape Symbol) = ∅ := rfl
+
+@[simp]
+lemma mapSome_nil : mapSome ([] : List Symbol) = ∅ := rfl
+
+@[simp]
+lemma empty_head : (∅ : StackTape Symbol).head = none := rfl
+
+@[simp]
+lemma empty_tail : (∅ : StackTape Symbol).tail = ∅ := rfl
+
 section Length
 
 /-- The length of the `StackTape` is the number of elements up to the last non-`none` element -/

--- a/Cslib/Foundations/Data/StackTape.lean
+++ b/Cslib/Foundations/Data/StackTape.lean
@@ -137,6 +137,8 @@ lemma cons_head_tail (l : StackTape Symbol) :
   rw [eq_iff]
   simp
 
+section mapSome
+
 /-- Create a `StackTape` from a list by mapping all elements to `some` -/
 @[scoped grind]
 def mapSome (l : List Symbol) : StackTape Symbol := ⟨l.map some, by simp⟩
@@ -159,16 +161,9 @@ lemma cons_head?_mapSome (l : List Symbol) :
   cases l <;> rfl
 
 @[simp]
-lemma cons_none_empty : cons none (∅ : StackTape Symbol) = ∅ := rfl
-
-@[simp]
 lemma mapSome_nil : mapSome ([] : List Symbol) = ∅ := rfl
 
-@[simp]
-lemma empty_head : (∅ : StackTape Symbol).head = none := rfl
-
-@[simp]
-lemma empty_tail : (∅ : StackTape Symbol).tail = ∅ := rfl
+end mapSome
 
 section Length
 

--- a/Cslib/Foundations/Data/StackTape.lean
+++ b/Cslib/Foundations/Data/StackTape.lean
@@ -86,10 +86,6 @@ def cons (x : Option Symbol) (xs : StackTape Symbol) : StackTape Symbol :=
 @[simp, scoped grind =]
 lemma cons_none_nil : cons none (nil : StackTape Symbol) = nil := rfl
 
-@[simp, scoped grind =]
-lemma cons_none_nil_toList : (cons none (nil : StackTape Symbol)).toList = [] := by
-  grind only [nil, cons]
-
 @[simp]
 lemma cons_some_toList (a : Symbol) (l : StackTape Symbol) :
     (cons (some a) l).toList = some a :: l.toList := by simp only [cons]
@@ -159,10 +155,6 @@ lemma tail_mapSome (l : List Symbol) : (mapSome l).tail = mapSome l.tail := by
 @[scoped grind =]
 lemma mapSome_cons (a : Symbol) (l : List Symbol) :
     mapSome (a :: l) = cons (some a) (mapSome l) := rfl
-
-@[scoped grind =]
-lemma cons_some_mapSome (a : Symbol) (l : List Symbol) :
-    cons (some a) (mapSome l) = mapSome (a :: l) := rfl
 
 @[scoped grind =]
 lemma cons_head?_mapSome (l : List Symbol) :

--- a/Cslib/Foundations/Data/StackTape.lean
+++ b/Cslib/Foundations/Data/StackTape.lean
@@ -70,7 +70,7 @@ instance : Inhabited (StackTape Symbol) where
 instance : EmptyCollection (StackTape Symbol) :=
   ⟨nil⟩
 
-@[simp, scoped grind =]
+@[simp]
 lemma empty_eq_nil : (∅ : StackTape Symbol) = nil := rfl
 
 @[simp, scoped grind =]
@@ -83,11 +83,12 @@ def cons (x : Option Symbol) (xs : StackTape Symbol) : StackTape Symbol :=
   | none, ⟨hd :: tl, hl⟩ => ⟨none :: hd :: tl, by grind⟩
   | some a, ⟨l, hl⟩ => ⟨some a :: l, by grind⟩
 
-@[simp, scoped grind =]
+@[simp]
 lemma cons_none_nil : cons none (nil : StackTape Symbol) = nil := rfl
 
+@[simp, scoped grind =]
 lemma cons_none_nil_toList : (cons none (nil : StackTape Symbol)).toList = [] := by
-  simp
+  grind only [nil, cons]
 
 @[simp]
 lemma cons_some_toList (a : Symbol) (l : StackTape Symbol) :
@@ -145,30 +146,27 @@ section MapSome
 @[scoped grind]
 def mapSome (l : List Symbol) : StackTape Symbol := ⟨l.map some, by simp⟩
 
-@[simp, scoped grind =]
+@[simp]
 lemma toList_mapSome (l : List Symbol) : (mapSome l).toList = l.map some := rfl
 
-@[simp, scoped grind =]
+@[simp]
 lemma head_mapSome (l : List Symbol) : (mapSome l).head = l.head? := by
   cases l <;> rfl
 
-@[scoped grind =]
 lemma tail_mapSome (l : List Symbol) : (mapSome l).tail = mapSome l.tail := by
   cases l <;> rfl
 
-@[scoped grind =]
 lemma mapSome_cons (a : Symbol) (l : List Symbol) :
     mapSome (a :: l) = cons (some a) (mapSome l) := rfl
 
-@[simp, scoped grind =]
+@[simp]
 lemma cons_head?_mapSome (l : List Symbol) :
     cons l.head? (mapSome l.tail) = mapSome l := by
   cases l <;> rfl
 
-@[scoped grind =]
 lemma mapSome_nil : mapSome ([] : List Symbol) = nil := rfl
 
-@[simp, scoped grind =]
+@[simp]
 lemma mapSome_eq_nil_iff (l : List Symbol) : mapSome l = nil ↔ l = [] := by
   cases l <;> simp [mapSome, nil]
 

--- a/Cslib/Foundations/Data/StackTape.lean
+++ b/Cslib/Foundations/Data/StackTape.lean
@@ -142,6 +142,7 @@ lemma cons_head_tail (l : StackTape Symbol) :
 section MapSome
 
 /-- Create a `StackTape` from a list by mapping all elements to `some` -/
+@[scoped grind]
 def mapSome (l : List Symbol) : StackTape Symbol := ⟨l.map some, by simp⟩
 
 @[simp, scoped grind =]

--- a/Cslib/Foundations/Data/StackTape.lean
+++ b/Cslib/Foundations/Data/StackTape.lean
@@ -70,7 +70,7 @@ instance : Inhabited (StackTape Symbol) where
 instance : EmptyCollection (StackTape Symbol) :=
   ⟨nil⟩
 
-@[simp]
+@[simp, scoped grind =]
 lemma empty_eq_nil : (∅ : StackTape Symbol) = nil := rfl
 
 @[simp, scoped grind =]
@@ -82,6 +82,9 @@ def cons (x : Option Symbol) (xs : StackTape Symbol) : StackTape Symbol :=
   | none, ⟨[], _⟩ => ⟨[], by grind⟩
   | none, ⟨hd :: tl, hl⟩ => ⟨none :: hd :: tl, by grind⟩
   | some a, ⟨l, hl⟩ => ⟨some a :: l, by grind⟩
+
+@[simp, scoped grind =]
+lemma cons_none_nil : cons none (nil : StackTape Symbol) = nil := rfl
 
 @[simp, scoped grind =]
 lemma cons_none_nil_toList : (cons none (nil : StackTape Symbol)).toList = [] := by
@@ -137,32 +140,39 @@ lemma cons_head_tail (l : StackTape Symbol) :
   rw [eq_iff]
   simp
 
-section mapSome
+section MapSome
 
 /-- Create a `StackTape` from a list by mapping all elements to `some` -/
-@[scoped grind]
 def mapSome (l : List Symbol) : StackTape Symbol := ⟨l.map some, by simp⟩
 
-@[simp]
-lemma mapSome_head (l : List Symbol) : (mapSome l).head = l.head? := by
+@[scoped grind =]
+lemma toList_mapSome (l : List Symbol) : (mapSome l).toList = l.map some := rfl
+
+@[scoped grind =]
+lemma head_mapSome (l : List Symbol) : (mapSome l).head = l.head? := by
   cases l <;> rfl
 
-@[simp]
-lemma mapSome_tail (l : List Symbol) : (mapSome l).tail = mapSome l.tail := by
+@[scoped grind =]
+lemma tail_mapSome (l : List Symbol) : (mapSome l).tail = mapSome l.tail := by
   cases l <;> rfl
 
+@[scoped grind =]
+lemma mapSome_cons (a : Symbol) (l : List Symbol) :
+    mapSome (a :: l) = cons (some a) (mapSome l) := rfl
+
+@[scoped grind =]
 lemma cons_some_mapSome (a : Symbol) (l : List Symbol) :
     cons (some a) (mapSome l) = mapSome (a :: l) := rfl
 
-@[simp]
+@[scoped grind =]
 lemma cons_head?_mapSome (l : List Symbol) :
     cons l.head? (mapSome l.tail) = mapSome l := by
   cases l <;> rfl
 
-@[simp]
+@[scoped grind =]
 lemma mapSome_nil : mapSome ([] : List Symbol) = nil := rfl
 
-end mapSome
+end MapSome
 
 section Length
 


### PR DESCRIPTION
Add lemmas describing how `StackTape.mapSome` and `cons` interact with `head`/`tail` and the empty tape, 

These are split out of #192 where they are used for reasoning about a left-to-right tape scan.

I'm not going to add any grind lemmas on these, since it seems like it's already covered by the definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)