### PR TITLE
feat(Automata): Regular languages are closed under reversal. 

### DIFF
--- a/Cslib.lean
+++ b/Cslib.lean
@@ -107,6 +107,7 @@ public import Cslib.Foundations.Semantics.LTS.MapLabel
 public import Cslib.Foundations.Semantics.LTS.Notation
 public import Cslib.Foundations.Semantics.LTS.OmegaExecution
 public import Cslib.Foundations.Semantics.LTS.Relation
+public import Cslib.Foundations.Semantics.LTS.Reverse
 public import Cslib.Foundations.Semantics.LTS.Simulation
 public import Cslib.Foundations.Semantics.LTS.Termination
 public import Cslib.Foundations.Semantics.LTS.Total

--- a/Cslib.lean
+++ b/Cslib.lean
@@ -21,6 +21,7 @@ public import Cslib.Computability.Automata.NA.Hist
 public import Cslib.Computability.Automata.NA.Loop
 public import Cslib.Computability.Automata.NA.Pair
 public import Cslib.Computability.Automata.NA.Prod
+public import Cslib.Computability.Automata.NA.Reverse
 public import Cslib.Computability.Automata.NA.Sum
 public import Cslib.Computability.Automata.NA.ToDA
 public import Cslib.Computability.Automata.NA.Total

--- a/Cslib/Computability/Automata/NA/Reverse.lean
+++ b/Cslib/Computability/Automata/NA/Reverse.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2026 Vignesh Karri. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Vignesh Karri
+-/
+
+module
+
+public import Cslib.Computability.Automata.NA.Basic
+
+/-! # Reversal of nondeterministic automata. -/
+
+@[expose] public section
+
+namespace Cslib.Automata.NA
+
+open Acceptor Language
+
+variable {Symbol State : Type*}
+
+/-- `na.reverse` reverses every transition of `na` and swaps its start and accept states,
+so that it accepts exactly the reversals of the words accepted by `na`. -/
+def FinAcc.reverse (na : FinAcc State Symbol) : FinAcc State Symbol where
+  Tr s x t := na.Tr t x s
+  start := na.accept
+  accept := na.start
+
+/-- Reversing an automaton twice gives back the original automaton. -/
+@[simp]
+theorem FinAcc.reverse_reverse (na : FinAcc State Symbol) : na.reverse.reverse = na := rfl
+
+/-- The multistep transitions of `na.reverse` are exactly the reversed multistep transitions
+of `na`. -/
+theorem reverse_mtr (na : FinAcc State Symbol) {xs : List Symbol} {s s' : State}
+    (hmtr : na.MTr s xs.reverse s') : na.reverse.MTr s' xs s := by
+  induction xs generalizing s s' with
+  | nil =>
+    simp_all
+  | cons x xs ih =>
+    simp only [List.reverse_cons] at hmtr
+    simp only [LTS.MTr.cons_iff]
+    obtain ⟨mid, h1, h2⟩ := LTS.MTr.split hmtr
+    simp only [LTS.MTr.singleton_iff] at h2
+    exact ⟨mid, h2, ih h1⟩
+
+/-- `na.reverse` accepts exactly the reversals of the words accepted by `na`. -/
+theorem reverse_language_eq (na : FinAcc State Symbol) :
+    language (na.reverse) = (language na).reverse := by
+  ext xs
+  simp only [mem_language, mem_reverse]
+  constructor
+  · intro h
+    simp only [Accepts] at h ⊢
+    obtain ⟨s, hs, s', hs', hmtr⟩ := h
+    rw [← List.reverse_reverse xs] at hmtr
+    exact ⟨s', hs', s, hs, reverse_mtr na.reverse hmtr⟩
+  · intro h_na
+    simp only [Accepts] at h_na ⊢
+    obtain ⟨s, hs, s', hs', hmtr⟩ := h_na
+    exact ⟨s', hs', s, hs, reverse_mtr na hmtr⟩
+
+end Cslib.Automata.NA

--- a/Cslib/Computability/Automata/NA/Reverse.lean
+++ b/Cslib/Computability/Automata/NA/Reverse.lean
@@ -18,30 +18,37 @@ open Acceptor Language
 
 variable {Symbol State : Type*}
 
+namespace FinAcc
+
 /-- `na.reverse` reverses every transition of `na` and swaps its start and accept states,
 so that it accepts exactly the reversals of the words accepted by `na`. -/
-def FinAcc.reverse (na : FinAcc State Symbol) : FinAcc State Symbol where
+def reverse (na : FinAcc State Symbol) : FinAcc State Symbol where
   Tr s x t := na.Tr t x s
   start := na.accept
   accept := na.start
 
 /-- Reversing an automaton twice gives back the original automaton. -/
 @[simp]
-theorem FinAcc.reverse_reverse (na : FinAcc State Symbol) : na.reverse.reverse = na := rfl
+theorem reverse_reverse (na : FinAcc State Symbol) : na.reverse.reverse = na := rfl
 
 /-- The multistep transitions of `na.reverse` are exactly the reversed multistep transitions
 of `na`. -/
-theorem reverse_mtr (na : FinAcc State Symbol) {xs : List Symbol} {s s' : State}
-    (hmtr : na.MTr s xs.reverse s') : na.reverse.MTr s' xs s := by
+theorem reverse_mtr_iff (na : FinAcc State Symbol) {xs : List Symbol} {s s' : State} :
+    na.reverse.MTr s' xs s ↔ na.MTr s xs.reverse s' := by
   induction xs generalizing s s' with
   | nil =>
-    simp_all
+    simp_all [eq_comm]
   | cons x xs ih =>
-    simp only [List.reverse_cons] at hmtr
+    simp only [List.reverse_cons]
     simp only [LTS.MTr.cons_iff]
-    obtain ⟨mid, h1, h2⟩ := LTS.MTr.split hmtr
-    simp only [LTS.MTr.singleton_iff] at h2
-    exact ⟨mid, h2, ih h1⟩
+    constructor
+    · intro hmtr
+      obtain ⟨mid, h1, h2⟩ := hmtr
+      exact LTS.MTr.stepR na.toLTS (ih.mp h2) h1
+    · intro hmtr
+      obtain ⟨mid, h1, h2⟩ := LTS.MTr.split hmtr
+      simp only [LTS.MTr.singleton_iff] at h2
+      exact ⟨mid, h2, ih.mpr h1⟩
 
 /-- `na.reverse` accepts exactly the reversals of the words accepted by `na`. -/
 theorem reverse_language_eq (na : FinAcc State Symbol) :
@@ -52,11 +59,17 @@ theorem reverse_language_eq (na : FinAcc State Symbol) :
   · intro h
     simp only [Accepts] at h ⊢
     obtain ⟨s, hs, s', hs', hmtr⟩ := h
-    rw [← List.reverse_reverse xs] at hmtr
-    exact ⟨s', hs', s, hs, reverse_mtr na.reverse hmtr⟩
+    exact ⟨s', hs', s, hs, (reverse_mtr_iff na).mp hmtr⟩
   · intro h_na
     simp only [Accepts] at h_na ⊢
     obtain ⟨s, hs, s', hs', hmtr⟩ := h_na
-    exact ⟨s', hs', s, hs, reverse_mtr na hmtr⟩
+    exact ⟨s', hs', s, hs, (reverse_mtr_iff na).mpr hmtr⟩
+
+/-- `na.reverse` accepts a word iff `na` accepts its reversal. -/
+theorem reverse_na_accepts (na : FinAcc State Symbol) (xs : List Symbol) :
+    Accepts na.reverse xs ↔ Accepts na xs.reverse := by
+  exact Set.ext_iff.mp (reverse_language_eq na) xs
+
+end FinAcc
 
 end Cslib.Automata.NA

--- a/Cslib/Computability/Automata/NA/Reverse.lean
+++ b/Cslib/Computability/Automata/NA/Reverse.lean
@@ -9,7 +9,19 @@ module
 public import Cslib.Computability.Automata.NA.Basic
 public import Cslib.Foundations.Semantics.LTS.Reverse
 
-/-! # Reversal of nondeterministic automata. -/
+/-!
+# Reversal of nondeterministic automata
+
+This file defines `Cslib.Automata.NA.FinAcc.reverse`, which reverses every transition of a
+nondeterministic automaton and swaps its start and accept states. Its underlying transition system
+is `Cslib.LTS.reverse`, so the transition results are inherited from
+`Cslib/Foundations/Semantics/LTS/Reverse.lean`.
+
+The main result is `FinAcc.reverse_language_eq`: the language accepted by `na.reverse` is the
+`Language.reverse` of the language accepted by `na`. It follows from `FinAcc.accepts_reverse`,
+the statement that `na.reverse` accepts `xs` iff `na` accepts `xs.reverse`.
+-/
+
 
 @[expose] public section
 

--- a/Cslib/Computability/Automata/NA/Reverse.lean
+++ b/Cslib/Computability/Automata/NA/Reverse.lean
@@ -17,7 +17,7 @@ namespace Cslib.Automata.NA
 
 open Acceptor Language
 
-variable {Symbol State : Type*}
+variable {State Symbol : Type*}
 
 namespace FinAcc
 
@@ -31,6 +31,10 @@ def reverse (na : FinAcc State Symbol) : FinAcc State Symbol where
 /-- Reversing an automaton twice gives back the original automaton. -/
 @[simp]
 theorem reverse_reverse (na : FinAcc State Symbol) : na.reverse.reverse = na := rfl
+
+/-- Reversal of an automaton is an involution. -/
+theorem reverse_involutive : Function.Involutive (reverse (State := State) (Symbol := Symbol)) :=
+  reverse_reverse
 
 /-- The multistep transitions of `na.reverse` are exactly the reversed multistep transitions
 of `na`. -/
@@ -46,6 +50,7 @@ theorem accepts_reverse {na : FinAcc State Symbol} {xs : List Symbol} :
   aesop
 
 /-- `na.reverse` accepts exactly the reversals of the words accepted by `na`. -/
+@[simp]
 theorem reverse_language_eq (na : FinAcc State Symbol) :
     language na.reverse = (language na).reverse := by
   ext xs

--- a/Cslib/Computability/Automata/NA/Reverse.lean
+++ b/Cslib/Computability/Automata/NA/Reverse.lean
@@ -38,26 +38,18 @@ of `na`. -/
 theorem reverse_mTr (na : FinAcc State Symbol) {xs : List Symbol} {s s' : State} :
     na.reverse.MTr s' xs s ↔ na.MTr s xs.reverse s' := LTS.reverse_mTr
 
-/-- `na.reverse` accepts exactly the reversals of the words accepted by `na`. -/
-theorem reverse_language_eq (na : FinAcc State Symbol) :
-    language na.reverse = (language na).reverse := by
-  ext xs
-  simp only [mem_language, mem_reverse]
-  constructor
-  · intro h
-    simp only [Accepts] at h ⊢
-    obtain ⟨s, hs, s', hs', hmtr⟩ := h
-    exact ⟨s', hs', s, hs, (reverse_mTr na).mp hmtr⟩
-  · intro h_na
-    simp only [Accepts] at h_na ⊢
-    obtain ⟨s, hs, s', hs', hmtr⟩ := h_na
-    exact ⟨s', hs', s, hs, (reverse_mTr na).mpr hmtr⟩
-
 /-- `na.reverse` accepts a word iff `na` accepts its reversal. -/
 @[simp]
 theorem accepts_reverse {na : FinAcc State Symbol} {xs : List Symbol} :
     Accepts na.reverse xs ↔ Accepts na xs.reverse := by
-  exact Set.ext_iff.mp (reverse_language_eq na) xs
+  simp only [Accepts, reverse_mTr]
+  aesop
+
+/-- `na.reverse` accepts exactly the reversals of the words accepted by `na`. -/
+theorem reverse_language_eq (na : FinAcc State Symbol) :
+    language na.reverse = (language na).reverse := by
+  ext xs
+  simp only [mem_language, mem_reverse, accepts_reverse]
 
 end FinAcc
 

--- a/Cslib/Computability/Automata/NA/Reverse.lean
+++ b/Cslib/Computability/Automata/NA/Reverse.lean
@@ -7,6 +7,7 @@ Authors: Vignesh Karri
 module
 
 public import Cslib.Computability.Automata.NA.Basic
+public import Cslib.Foundations.Semantics.LTS.Reverse
 
 /-! # Reversal of nondeterministic automata. -/
 
@@ -23,7 +24,7 @@ namespace FinAcc
 /-- `na.reverse` reverses every transition of `na` and swaps its start and accept states,
 so that it accepts exactly the reversals of the words accepted by `na`. -/
 def reverse (na : FinAcc State Symbol) : FinAcc State Symbol where
-  Tr s x t := na.Tr t x s
+  toLTS := na.toLTS.reverse
   start := na.accept
   accept := na.start
 
@@ -33,21 +34,9 @@ theorem reverse_reverse (na : FinAcc State Symbol) : na.reverse.reverse = na := 
 
 /-- The multistep transitions of `na.reverse` are exactly the reversed multistep transitions
 of `na`. -/
-theorem reverse_mtr_iff (na : FinAcc State Symbol) {xs : List Symbol} {s s' : State} :
-    na.reverse.MTr s' xs s ↔ na.MTr s xs.reverse s' := by
-  induction xs generalizing s s' with
-  | nil =>
-    simp_all [eq_comm]
-  | cons x xs ih =>
-    simp only [List.reverse_cons]
-    simp only [LTS.MTr.cons_iff]
-    constructor
-    · rintro ⟨mid, h1, h2⟩
-      exact LTS.MTr.stepR na.toLTS (ih.mp h2) h1
-    · intro hmtr
-      obtain ⟨mid, h1, h2⟩ := LTS.MTr.split hmtr
-      simp only [LTS.MTr.singleton_iff] at h2
-      exact ⟨mid, h2, ih.mpr h1⟩
+@[simp]
+theorem reverse_mTr (na : FinAcc State Symbol) {xs : List Symbol} {s s' : State} :
+    na.reverse.MTr s' xs s ↔ na.MTr s xs.reverse s' := LTS.reverse_mTr
 
 /-- `na.reverse` accepts exactly the reversals of the words accepted by `na`. -/
 theorem reverse_language_eq (na : FinAcc State Symbol) :
@@ -58,11 +47,11 @@ theorem reverse_language_eq (na : FinAcc State Symbol) :
   · intro h
     simp only [Accepts] at h ⊢
     obtain ⟨s, hs, s', hs', hmtr⟩ := h
-    exact ⟨s', hs', s, hs, (reverse_mtr_iff na).mp hmtr⟩
+    exact ⟨s', hs', s, hs, (reverse_mTr na).mp hmtr⟩
   · intro h_na
     simp only [Accepts] at h_na ⊢
     obtain ⟨s, hs, s', hs', hmtr⟩ := h_na
-    exact ⟨s', hs', s, hs, (reverse_mtr_iff na).mpr hmtr⟩
+    exact ⟨s', hs', s, hs, (reverse_mTr na).mpr hmtr⟩
 
 /-- `na.reverse` accepts a word iff `na` accepts its reversal. -/
 @[simp]

--- a/Cslib/Computability/Automata/NA/Reverse.lean
+++ b/Cslib/Computability/Automata/NA/Reverse.lean
@@ -42,8 +42,7 @@ theorem reverse_mtr_iff (na : FinAcc State Symbol) {xs : List Symbol} {s s' : St
     simp only [List.reverse_cons]
     simp only [LTS.MTr.cons_iff]
     constructor
-    · intro hmtr
-      obtain ⟨mid, h1, h2⟩ := hmtr
+    · rintro ⟨mid, h1, h2⟩
       exact LTS.MTr.stepR na.toLTS (ih.mp h2) h1
     · intro hmtr
       obtain ⟨mid, h1, h2⟩ := LTS.MTr.split hmtr
@@ -52,7 +51,7 @@ theorem reverse_mtr_iff (na : FinAcc State Symbol) {xs : List Symbol} {s s' : St
 
 /-- `na.reverse` accepts exactly the reversals of the words accepted by `na`. -/
 theorem reverse_language_eq (na : FinAcc State Symbol) :
-    language (na.reverse) = (language na).reverse := by
+    language na.reverse = (language na).reverse := by
   ext xs
   simp only [mem_language, mem_reverse]
   constructor
@@ -66,7 +65,8 @@ theorem reverse_language_eq (na : FinAcc State Symbol) :
     exact ⟨s', hs', s, hs, (reverse_mtr_iff na).mpr hmtr⟩
 
 /-- `na.reverse` accepts a word iff `na` accepts its reversal. -/
-theorem reverse_na_accepts (na : FinAcc State Symbol) (xs : List Symbol) :
+@[simp]
+theorem accepts_reverse {na : FinAcc State Symbol} {xs : List Symbol} :
     Accepts na.reverse xs ↔ Accepts na xs.reverse := by
   exact Set.ext_iff.mp (reverse_language_eq na) xs
 

--- a/Cslib/Computability/Automata/NA/Reverse.lean
+++ b/Cslib/Computability/Automata/NA/Reverse.lean
@@ -36,6 +36,14 @@ theorem reverse_reverse (na : FinAcc State Symbol) : na.reverse.reverse = na := 
 theorem reverse_involutive : Function.Involutive (reverse (State := State) (Symbol := Symbol)) :=
   reverse_reverse
 
+/-- The start states of `na.reverse` are the accept states of `na`. -/
+@[simp, grind =]
+theorem reverse_start (na : FinAcc State Symbol) : na.reverse.start = na.accept := rfl
+
+/-- The accept states of `na.reverse` are the start states of `na`. -/
+@[simp, grind =]
+theorem reverse_accept (na : FinAcc State Symbol) : na.reverse.accept = na.start := rfl
+
 /-- The multistep transitions of `na.reverse` are exactly the reversed multistep transitions
 of `na`. -/
 @[simp]
@@ -46,15 +54,13 @@ theorem reverse_mTr (na : FinAcc State Symbol) {xs : List Symbol} {s s' : State}
 @[simp]
 theorem accepts_reverse {na : FinAcc State Symbol} {xs : List Symbol} :
     Accepts na.reverse xs ↔ Accepts na xs.reverse := by
-  simp only [Accepts, reverse_mTr]
-  aesop
+  grind [Accepts, reverse_mTr]
 
 /-- `na.reverse` accepts exactly the reversals of the words accepted by `na`. -/
 @[simp]
 theorem reverse_language_eq (na : FinAcc State Symbol) :
     language na.reverse = (language na).reverse := by
-  ext xs
-  simp only [mem_language, mem_reverse, accepts_reverse]
+  ext; simp
 
 end FinAcc
 

--- a/Cslib/Computability/Languages/RegularLanguage.lean
+++ b/Cslib/Computability/Languages/RegularLanguage.lean
@@ -193,14 +193,14 @@ theorem IsRegular.congr_fin_index {Symbol : Type}
 
 open NA in
 /-- The reversal of a regular language is regular. -/
-theorem IsRegular.reverse {l : Language Symbol} (h : l.IsRegular) : (l.reverse).IsRegular := by
+theorem IsRegular.reverse {l : Language Symbol} (h : l.IsRegular) : l.reverse.IsRegular := by
   rw [IsRegular.iff_nfa] at h ⊢
   obtain ⟨State, h_fin, nfa, rfl⟩ := h
   use State, inferInstance, nfa.reverse, FinAcc.reverse_language_eq nfa
 
 /-- A language is regular iff its reversal is regular. -/
 @[simp]
-theorem IsRegular.reverse_iff {l : Language Symbol} : (l.reverse).IsRegular ↔ l.IsRegular := by
+theorem IsRegular.reverse_iff {l : Language Symbol} : l.reverse.IsRegular ↔ l.IsRegular := by
   constructor
   · intro h
     simpa using IsRegular.reverse h

--- a/Cslib/Computability/Languages/RegularLanguage.lean
+++ b/Cslib/Computability/Languages/RegularLanguage.lean
@@ -11,6 +11,7 @@ public import Cslib.Computability.Automata.DA.Prod
 public import Cslib.Computability.Automata.DA.ToNA
 public import Cslib.Computability.Automata.NA.Concat
 public import Cslib.Computability.Automata.NA.Loop
+public import Cslib.Computability.Automata.NA.Reverse
 public import Cslib.Computability.Automata.NA.ToDA
 public import Mathlib.Computability.DFA
 public import Mathlib.Computability.RegularExpressions
@@ -205,6 +206,14 @@ theorem IsRegular.char (a : Symbol) : ({[a]} : Language Symbol).IsRegular := by
     constructor
     · induction xs using List.reverseRec <;> grind
     · simp_all [flts, List.append_eq_cons_iff]
+
+open NA in
+/-- The reversal of a regular language is regular. -/
+@[simp]
+theorem IsRegular.reverse {l : Language Symbol} (h : l.IsRegular) : (l.reverse).IsRegular := by
+  rw [IsRegular.iff_nfa] at h ⊢
+  obtain ⟨State, h_fin, nfa, rfl⟩ := h
+  use State, inferInstance, nfa.reverse, reverse_language_eq nfa
 
 /-- Languages matching regular expressions are regular. -/
 theorem IsRegular.regex {r : RegularExpression Symbol} :

--- a/Cslib/Computability/Languages/RegularLanguage.lean
+++ b/Cslib/Computability/Languages/RegularLanguage.lean
@@ -191,6 +191,21 @@ theorem IsRegular.congr_fin_index {Symbol : Type}
   use Quotient c.eq, inferInstance, ⟨c.toDA, {a}⟩
   exact DA.FinAcc.congr_language_eq
 
+open NA in
+/-- The reversal of a regular language is regular. -/
+@[simp]
+theorem IsRegular.reverse {l : Language Symbol} (h : l.IsRegular) : (l.reverse).IsRegular := by
+  rw [IsRegular.iff_nfa] at h ⊢
+  obtain ⟨State, h_fin, nfa, rfl⟩ := h
+  use State, inferInstance, nfa.reverse, FinAcc.reverse_language_eq nfa
+
+/-- A language is regular iff its reversal is regular. -/
+theorem IsRegular.reverse_iff {l : Language Symbol} : (l.reverse).IsRegular ↔ l.IsRegular := by
+  constructor
+  · intro h
+    simpa using IsRegular.reverse h
+  · exact IsRegular.reverse
+
 /-- The language containing only the one character string `a` is regular. -/
 @[simp]
 theorem IsRegular.char (a : Symbol) : ({[a]} : Language Symbol).IsRegular := by
@@ -206,22 +221,6 @@ theorem IsRegular.char (a : Symbol) : ({[a]} : Language Symbol).IsRegular := by
     constructor
     · induction xs using List.reverseRec <;> grind
     · simp_all [flts, List.append_eq_cons_iff]
-
-open NA in
-/-- The reversal of a regular language is regular. -/
-@[simp]
-theorem IsRegular.reverse {l : Language Symbol} (h : l.IsRegular) : (l.reverse).IsRegular := by
-  rw [IsRegular.iff_nfa] at h ⊢
-  obtain ⟨State, h_fin, nfa, rfl⟩ := h
-  use State, inferInstance, nfa.reverse, FinAcc.reverse_language_eq nfa
-
-/-- A language is regular iff its reversal is regular. -/
-@[simp]
-theorem IsRegular.reverse_iff {l : Language Symbol} : (l.reverse).IsRegular ↔ l.IsRegular := by
-  constructor
-  · intro h
-    simpa using IsRegular.reverse h
-  · exact IsRegular.reverse
 
 /-- Languages matching regular expressions are regular. -/
 theorem IsRegular.regex {r : RegularExpression Symbol} :

--- a/Cslib/Computability/Languages/RegularLanguage.lean
+++ b/Cslib/Computability/Languages/RegularLanguage.lean
@@ -193,13 +193,13 @@ theorem IsRegular.congr_fin_index {Symbol : Type}
 
 open NA in
 /-- The reversal of a regular language is regular. -/
-@[simp]
 theorem IsRegular.reverse {l : Language Symbol} (h : l.IsRegular) : (l.reverse).IsRegular := by
   rw [IsRegular.iff_nfa] at h ⊢
   obtain ⟨State, h_fin, nfa, rfl⟩ := h
   use State, inferInstance, nfa.reverse, FinAcc.reverse_language_eq nfa
 
 /-- A language is regular iff its reversal is regular. -/
+@[simp]
 theorem IsRegular.reverse_iff {l : Language Symbol} : (l.reverse).IsRegular ↔ l.IsRegular := by
   constructor
   · intro h

--- a/Cslib/Computability/Languages/RegularLanguage.lean
+++ b/Cslib/Computability/Languages/RegularLanguage.lean
@@ -213,7 +213,15 @@ open NA in
 theorem IsRegular.reverse {l : Language Symbol} (h : l.IsRegular) : (l.reverse).IsRegular := by
   rw [IsRegular.iff_nfa] at h ⊢
   obtain ⟨State, h_fin, nfa, rfl⟩ := h
-  use State, inferInstance, nfa.reverse, reverse_language_eq nfa
+  use State, inferInstance, nfa.reverse, FinAcc.reverse_language_eq nfa
+
+/-- A language is regular iff its reversal is regular. -/
+@[simp]
+theorem IsRegular.reverse_iff {l : Language Symbol} : (l.reverse).IsRegular ↔ l.IsRegular := by
+  constructor
+  · intro h
+    simpa using IsRegular.reverse h
+  · exact IsRegular.reverse
 
 /-- Languages matching regular expressions are regular. -/
 theorem IsRegular.regex {r : RegularExpression Symbol} :

--- a/Cslib/Foundations/Semantics/LTS/Reverse.lean
+++ b/Cslib/Foundations/Semantics/LTS/Reverse.lean
@@ -6,7 +6,6 @@ Authors: Vignesh Karri
 
 module
 
-public import Cslib.Foundations.Semantics.LTS.Basic
 public import Cslib.Foundations.Semantics.LTS.Execution
 
 /-!

--- a/Cslib/Foundations/Semantics/LTS/Reverse.lean
+++ b/Cslib/Foundations/Semantics/LTS/Reverse.lean
@@ -96,16 +96,8 @@ theorem reverse_boundedUpTo {lts : LTS State Label} {n : ℕ} :
 and endpoints reversed. -/
 theorem Execution.reverse {lts : LTS State Label} (h : lts.Execution s μs s' ss) :
     lts.reverse.Execution s' μs.reverse s ss.reverse := by
-  induction μs generalizing s s' ss with
-  | nil => grind
-  | cons μ μs ih =>
-    cases ss with
-    | nil => grind
-    | cons t ts =>
-      obtain rfl : s = t := by grind
-      have htr : lts.Tr s μ (ts[0]'(by grind)) := by grind
-      simpa using Execution.comp (ih (Execution.cons_invert h))
-        (Execution.stepL htr (Execution.refl lts.reverse s))
+  use by grind
+  grind [reverse_tr]
 
 /-- An execution of `lts.reverse` is an execution of `lts` with the labels, states
 and endpoints reversed. -/

--- a/Cslib/Foundations/Semantics/LTS/Reverse.lean
+++ b/Cslib/Foundations/Semantics/LTS/Reverse.lean
@@ -16,6 +16,8 @@ public import Cslib.Foundations.Semantics.LTS.Execution
 
 namespace Cslib.LTS
 
+variable {State Label : Type*}
+
 section Reverse
 
 /-- Constructs an LTS by reversing the transitions of an existing LTS. -/
@@ -30,6 +32,10 @@ theorem reverse_tr {lts : LTS State Label} :
 /-- Reversing an LTS twice gives back the original LTS. -/
 @[simp]
 theorem reverse_reverse (lts : LTS State Label) : lts.reverse.reverse = lts := rfl
+
+/-- Reversal of an LTS is an involution. -/
+theorem reverse_involutive : Function.Involutive (reverse (Label := Label) (State := State)) :=
+  reverse_reverse
 
 /-- The multistep transitions of `lts.reverse` are exactly the reversed multistep transitions of
 `lts`. -/
@@ -48,11 +54,7 @@ theorem reverse_mTr {lts : LTS State Label} :
 theorem reverse_canReach {lts : LTS State Label} :
     lts.reverse.CanReach s s' ↔ lts.CanReach s' s := by
   simp only [CanReach, reverse_mTr]
-  constructor
-  · rintro ⟨μs, h⟩
-    exact ⟨_, h⟩
-  · rintro ⟨μs, h⟩
-    exact ⟨μs.reverse, by simpa using h⟩
+  conv_rhs => rw [List.reverse_involutive.surjective.exists]
 
 /-- The unlabelled transitions of `lts.reverse` are those of `lts` with the endpoints swapped. -/
 @[simp]

--- a/Cslib/Foundations/Semantics/LTS/Reverse.lean
+++ b/Cslib/Foundations/Semantics/LTS/Reverse.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2026 Vignesh Karri. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Vignesh Karri
+-/
+
+module
+
+public import Cslib.Foundations.Semantics.LTS.Basic
+
+/-!
+# Reverse operation for LTS.
+-/
+
+@[expose] public section
+
+namespace Cslib.LTS
+
+section Reverse
+
+/-- Constructs an LTS by reversing the transitions of an existing LTS. -/
+def reverse (lts : LTS State Label) : LTS State Label where
+  Tr s μ s' := lts.Tr s' μ s
+
+@[simp]
+theorem reverse_tr {lts : LTS State Label} :
+    (lts.reverse).Tr s μ s' ↔ lts.Tr s' μ s := by rfl
+
+/-- Reversing an LTS twice gives back the original LTS. -/
+@[simp]
+theorem reverse_reverse (lts : LTS State Label) : lts.reverse.reverse = lts := rfl
+
+/-- The multistep transitions of `lts.reverse` are exactly the reversed multistep transitions of
+`lts` -/
+@[simp]
+theorem reverse_mTr {lts : LTS State Label} :
+    lts.reverse.MTr s' μs s ↔ lts.MTr s μs.reverse s' := by
+  induction μs generalizing s s' with
+  | nil =>
+    simp_all [eq_comm]
+  | cons x xs ih =>
+    simp only [List.reverse_cons, LTS.MTr.cons_iff]
+    constructor
+    · rintro ⟨mid, h1, h2⟩
+      exact LTS.MTr.stepR lts (ih.mp h2) h1
+    · intro hmtr
+      obtain ⟨mid, h1, h2⟩ := LTS.MTr.split hmtr
+      simp only [LTS.MTr.singleton_iff] at h2
+      exact ⟨mid, h2, ih.mpr h1⟩
+
+end Reverse
+
+end Cslib.LTS

--- a/Cslib/Foundations/Semantics/LTS/Reverse.lean
+++ b/Cslib/Foundations/Semantics/LTS/Reverse.lean
@@ -9,7 +9,16 @@ module
 public import Cslib.Foundations.Semantics.LTS.Execution
 
 /-!
-# Reverse operation for LTS.
+# Reverse operation for LTS
+
+This file defines `Cslib.LTS.reverse`, which reverses every transition of an LTS.
+`reverse_canReach`, `reverse_unlabelledTr`, `reverse_image`, `reverse_imageMultistep`,
+`reverse_hasOutLabel` and `reverse_boundedUpTo` each state a property about `lts.reverse` in
+terms of `lts`.
+
+`reverse_mTr` states that the multistep transitions of `lts.reverse` are the reversed
+multistep transitions of `lts`. `reverse_execution` is the same statement for
+executions, and is derived from `Execution.reverse`.
 -/
 
 @[expose] public section

--- a/Cslib/Foundations/Semantics/LTS/Reverse.lean
+++ b/Cslib/Foundations/Semantics/LTS/Reverse.lean
@@ -105,7 +105,7 @@ and endpoints reversed. -/
 @[simp]
 theorem reverse_execution {lts : LTS State Label} :
     lts.reverse.Execution s μs s' ss ↔ lts.Execution s' μs.reverse s ss.reverse :=
-  ⟨fun h => by simpa using h.reverse, fun h => by simpa using h.reverse⟩
+  ⟨fun h => h.reverse, fun h => by simpa using h.reverse⟩
 
 end Reverse
 

--- a/Cslib/Foundations/Semantics/LTS/Reverse.lean
+++ b/Cslib/Foundations/Semantics/LTS/Reverse.lean
@@ -7,6 +7,7 @@ Authors: Vignesh Karri
 module
 
 public import Cslib.Foundations.Semantics.LTS.Basic
+public import Cslib.Foundations.Semantics.LTS.Execution
 
 /-!
 # Reverse operation for LTS.
@@ -22,6 +23,7 @@ section Reverse
 def reverse (lts : LTS State Label) : LTS State Label where
   Tr s μ s' := lts.Tr s' μ s
 
+/-- The transitions of `lts.reverse` are exactly the reversed transitions of `lts`. -/
 @[simp]
 theorem reverse_tr {lts : LTS State Label} :
     (lts.reverse).Tr s μ s' ↔ lts.Tr s' μ s := by rfl
@@ -31,22 +33,85 @@ theorem reverse_tr {lts : LTS State Label} :
 theorem reverse_reverse (lts : LTS State Label) : lts.reverse.reverse = lts := rfl
 
 /-- The multistep transitions of `lts.reverse` are exactly the reversed multistep transitions of
-`lts` -/
+`lts`. -/
 @[simp]
 theorem reverse_mTr {lts : LTS State Label} :
     lts.reverse.MTr s' μs s ↔ lts.MTr s μs.reverse s' := by
   induction μs generalizing s s' with
   | nil =>
-    simp_all [eq_comm]
+    simp [eq_comm]
   | cons x xs ih =>
-    simp only [List.reverse_cons, LTS.MTr.cons_iff]
-    constructor
-    · rintro ⟨mid, h1, h2⟩
-      exact LTS.MTr.stepR lts (ih.mp h2) h1
-    · intro hmtr
-      obtain ⟨mid, h1, h2⟩ := LTS.MTr.split hmtr
-      simp only [LTS.MTr.singleton_iff] at h2
-      exact ⟨mid, h2, ih.mpr h1⟩
+    simp_rw [List.reverse_cons, MTr.append_iff, MTr.singleton_iff, MTr.cons_iff, and_comm, ih,
+      reverse_tr]
+
+/-- `lts.reverse` can reach `s'` from `s` iff `lts` can reach `s` from `s'`. -/
+@[simp]
+theorem reverse_canReach {lts : LTS State Label} :
+    lts.reverse.CanReach s s' ↔ lts.CanReach s' s := by
+  simp only [CanReach, reverse_mTr]
+  constructor
+  · rintro ⟨μs, h⟩
+    exact ⟨_, h⟩
+  · rintro ⟨μs, h⟩
+    exact ⟨μs.reverse, by simpa using h⟩
+
+/-- The unlabelled transitions of `lts.reverse` are those of `lts` with the endpoints swapped. -/
+@[simp]
+theorem reverse_unlabelledTr {lts : LTS State Label} :
+    lts.reverse.UnlabelledTr s s' ↔ lts.UnlabelledTr s' s := Iff.rfl
+
+/-- The `μ`-image of a state in `lts.reverse` is its `μ`-preimage in `lts`. -/
+@[simp]
+theorem reverse_image {lts : LTS State Label} :
+    lts.reverse.image s μ = {s' | lts.Tr s' μ s} := rfl
+
+/-- Membership form of `reverse_image`. -/
+theorem mem_reverse_image {lts : LTS State Label} :
+    s' ∈ lts.reverse.image s μ ↔ s ∈ lts.image s' μ := Iff.rfl
+
+/-- The `μs`-image of a state in `lts.reverse` is its `μs.reverse`-preimage in `lts`. -/
+@[simp]
+theorem reverse_imageMultistep {lts : LTS State Label} :
+    lts.reverse.imageMultistep s μs = {s' | lts.MTr s' μs.reverse s} :=
+  Set.ext fun _ => reverse_mTr
+
+/-- Membership version of `reverse_imageMultistep`. -/
+theorem mem_reverse_imageMultistep {lts : LTS State Label} :
+    s' ∈ lts.reverse.imageMultistep s μs ↔ s ∈ lts.imageMultistep s' μs.reverse := reverse_mTr
+
+/-- A state has `μ` as an outgoing label in `lts.reverse` iff it has `μ` as an incoming
+label in `lts`. -/
+@[simp]
+theorem reverse_hasOutLabel {lts : LTS State Label} :
+    lts.reverse.HasOutLabel s μ ↔ ∃ s', lts.Tr s' μ s := Iff.rfl
+
+/-- `lts.reverse` is bounded up to `n` iff `lts` is. -/
+@[simp]
+theorem reverse_boundedUpTo {lts : LTS State Label} {n : ℕ} :
+    lts.reverse.BoundedUpTo n ↔ lts.BoundedUpTo n := by
+  constructor <;> intro h s₁ μs s₂ hmtr <;> simpa using h s₂ μs.reverse s₁ (by simpa using hmtr)
+
+/-- Reversing an execution of `lts` gives an execution of `lts.reverse`, with the labels, states
+and endpoints reversed. -/
+theorem Execution.reverse {lts : LTS State Label} (h : lts.Execution s μs s' ss) :
+    lts.reverse.Execution s' μs.reverse s ss.reverse := by
+  induction μs generalizing s s' ss with
+  | nil => grind
+  | cons μ μs ih =>
+    cases ss with
+    | nil => grind
+    | cons t ts =>
+      obtain rfl : s = t := by grind
+      have htr : lts.Tr s μ (ts[0]'(by grind)) := by grind
+      simpa using Execution.comp (ih (Execution.cons_invert h))
+        (Execution.stepL htr (Execution.refl lts.reverse s))
+
+/-- An execution of `lts.reverse` is an execution of `lts` with the labels, states
+and endpoints reversed. -/
+@[simp]
+theorem reverse_execution {lts : LTS State Label} :
+    lts.reverse.Execution s μs s' ss ↔ lts.Execution s' μs.reverse s ss.reverse :=
+  ⟨fun h => by simpa using h.reverse, fun h => by simpa using h.reverse⟩
 
 end Reverse
 

--- a/Cslib/Foundations/Semantics/LTS/Reverse.lean
+++ b/Cslib/Foundations/Semantics/LTS/Reverse.lean
@@ -96,8 +96,9 @@ theorem reverse_boundedUpTo {lts : LTS State Label} {n : ℕ} :
 and endpoints reversed. -/
 theorem Execution.reverse {lts : LTS State Label} (h : lts.Execution s μs s' ss) :
     lts.reverse.Execution s' μs.reverse s ss.reverse := by
-  use by grind
-  grind [reverse_tr]
+  obtain ⟨_, _, _, _⟩ := h
+  use by simpa
+  grind only [reverse_tr, = List.getElem_reverse, = List.length_reverse]
 
 /-- An execution of `lts.reverse` is an execution of `lts` with the labels, states
 and endpoints reversed. -/


### PR DESCRIPTION
Proves that A^R = {w^R | w ∈ A} is regular if A is regular, i.e regular languages are closed under reversal. The proof takes the NFA for A and constructs a new NFA by swapping the accept and start states and reversing all the transition arrows. 

`Reverse.lean` defines the reversal of a `FinAcc` and proves that it accepts the reverse of the language accepted by the original automaton. The Language reversal is defined in mathlib. 

Added a theorem `IsRegular.reverse` in `RegularLanguage.lean` to prove that regular languages are closed under reversal. 

AI Usage : I wrote down all the theorem statements and initial proofs with minimal. I then used claude to rewrite proofs for style compliance. 