### PR TITLE
feat(LocallyNameless): add `deriving DecidableEq` to `Term`

### DIFF
--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/Basic.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/Basic.lean
@@ -41,6 +41,7 @@ inductive Term (Var : Type u)
 | abs  : Term Var → Term Var
 /-- Function application. -/
 | app  : Term Var → Term Var → Term Var
+deriving DecidableEq
 
 namespace Term
 


### PR DESCRIPTION


Give Term Var an automatic decidable equality instance, so equality between terms can be decided computationally