### PR TITLE
chore: Fix linter warnings in docstrings

### DIFF
--- a/Cslib/Computability/Languages/OmegaLanguage.lean
+++ b/Cslib/Computability/Languages/OmegaLanguage.lean
@@ -46,11 +46,11 @@ denote languages (namely, sets of finite sequences of type `List α`).
 ## Main theorems
 
 * Many algebraic properties of the above operations.
-* omegaPow_seq_prop: an alternative characterization of `l^ω`.
-* omegaPow_coind: a "coinductive" rule for proving `p` is a subset of `l^ω`.
-* hmul_omegaPow_eq_omegaPow: `l * l^ω = l^ω`.
-* kstar_omegaPow_eq_omegaPow: `(l∗)^ω = l^ω`.
-* kstar_hmul_omegaPow_eq_omegaPow: `l∗ * l^ω = l^ω`.
+* `omegaPow_seq_prop`: an alternative characterization of `l^ω`.
+* `omegaPow_coind`: a "coinductive" rule for proving `p` is a subset of `l^ω`.
+* `hmul_omegaPow_eq_omegaPow`: `l * l^ω = l^ω`.
+* `kstar_omegaPow_eq_omegaPow`: `(l∗)^ω = l^ω`.
+* `kstar_hmul_omegaPow_eq_omegaPow`: `l∗ * l^ω = l^ω`.
 
 ## TODO
 

--- a/Cslib/Foundations/Data/OmegaSequence/Flatten.lean
+++ b/Cslib/Foundations/Data/OmegaSequence/Flatten.lean
@@ -129,8 +129,8 @@ theorem map_length_take_sum {ls : ωSequence (List α)} (n : ℕ) :
     (List.map List.length (take n ls)).sum = ls.cumLen n := by
   induction n <;> grind [take_succ']
 
-/-- `In fact, (ls.take n).flatten` is `ls.flatten.take (ls.cumLen n)`
-and (ls.drop n).flatten` is `ls.flatten.drop (ls.cumLen n)`. -/
+/-- In fact, `(ls.take n).flatten` is `ls.flatten.take (ls.cumLen n)`
+and `(ls.drop n).flatten` is `ls.flatten.drop (ls.cumLen n)`. -/
 theorem flatten_take_drop [Inhabited α]
     {ls : ωSequence (List α)} (h_ls : ∀ k, (ls k).length > 0) (n : ℕ) :
     (ls.take n).flatten = ls.flatten.take (ls.cumLen n) ∧

--- a/Cslib/Languages/CombinatoryLogic/Basic.lean
+++ b/Cslib/Languages/CombinatoryLogic/Basic.lean
@@ -23,7 +23,7 @@ public import Cslib.Languages.CombinatoryLogic.Defs
 ## Main results
 
 - Bracket abstraction: an algorithm `Polynomial.toSKI` to convert a polynomial
-$Γ(x_0, ..., x_{n-1})$ into a term such that (`Polynomial.toSKI_correct`)
+$Γ(x_0, ..., x_\{n-1\})$ into a term such that (`Polynomial.toSKI_correct`)
 `Γ.toSKI ⬝ t₁ ⬝ ... ⬝ tₙ` reduces to `Γ(t₁, ..., tₙ)`.
 
 ## References

--- a/Cslib/Logics/LinearLogic/CLL/PhaseSemantics/Basic.lean
+++ b/Cslib/Logics/LinearLogic/CLL/PhaseSemantics/Basic.lean
@@ -115,7 +115,7 @@ def biorthogonalClosure : ClosureOperator (Set P) where
 /-! # Basic theory of phase spaces -/
 
 /--
-Given a phase space (P, ⊥) and a set of subsets (Gᵢ)_{i ∈ I} of P, we have that
+Given a phase space (P, ⊥) and a family of subsets (Gᵢ) of P indexed by i ∈ I, we have that
 (⋃ᵢ Gᵢ)⫠ = ⋂ᵢ Gᵢ⫠.
 -/
 lemma orth_iUnion {ι : Sort*} (G : ι → Set P) :
@@ -131,7 +131,7 @@ lemma orth_iUnion {ι : Sort*} (G : ι → Set P) :
     grind
 
 /--
-Given a phase space (P, ⊥) and a set of subsets (Gᵢ)_{i ∈ I} of P, we have that
+Given a phase space (P, ⊥) and a family of subsets (Gᵢ) of P indexed by i ∈ I, we have that
 ∩ᵢ Gᵢ⫠⫠ = (∪ᵢ Gᵢ⫠)⫠.
 -/
 lemma iInter_biorth_eq_orth_iUnion_orth {ι : Sort*} (G : ι → Set P) :

--- a/Cslib/Logics/Propositional/NaturalDeduction/Basic.lean
+++ b/Cslib/Logics/Propositional/NaturalDeduction/Basic.lean
@@ -76,14 +76,14 @@ abbrev Ctx (Atom) := Finset (Proposition Atom)
 def Ctx.subst {Atom Atom' : Type u} [DecidableEq Atom'] (f : Atom → Proposition Atom') :
     Ctx Atom → Ctx Atom' := Finset.image (· >>= f)
 
-/-- Sequents {A₁, ..., Aₙ} ⊢ B. -/
+/-- Sequents \{A₁, ..., Aₙ\} ⊢ B. -/
 abbrev Sequent {Atom} := Ctx Atom × Proposition Atom
 
 @[inherit_doc Sequent]
 scoped notation Γ:60 " ⊢ " A => (⟨Γ, A⟩ : Sequent)
 
-/-- A `T`-derivation of {A₁, ..., Aₙ} ⊢ B demonstrates B using (undischarged) assumptions among Aᵢ,
-possibly appealing to axioms from `T`. -/
+/-- A `T`-derivation of \{A₁, ..., Aₙ\} ⊢ B demonstrates B using (undischarged) assumptions
+among Aᵢ, possibly appealing to axioms from `T`. -/
 inductive Theory.Derivation {T : Theory Atom} : Ctx Atom → Proposition Atom → Type u where
   /-- Axiom -/
   | ax {Γ : Ctx Atom} {A : Proposition Atom} (_ : A ∈ T) : Derivation Γ A


### PR DESCRIPTION
Fixes linter warnings by escaping characters special for verso.