### PR TITLE
chore: Fix linter by merging with grind tactics

### DIFF
--- a/Cslib/Computability/Automata/EpsilonNA/ToSingleAccept.lean
+++ b/Cslib/Computability/Automata/EpsilonNA/ToSingleAccept.lean
@@ -206,9 +206,7 @@ theorem toSingleAccept_sTr_none_none {a : εNA.FinAcc State Symbol}
     (h : a.toSingleAccept.STr none x os) : x = none ∧ os = none := by
   cases h
   case refl => trivial
-  case tr osb₁ osb₂ h₁ h₂ h₃ =>
-  have : osb₁ = none := toSingleAccept_τSTr_antiDerivative_none h₁
-  grind
+  case tr osb₁ osb₂ h₁ h₂ h₃ => grind
 
 @[scoped grind →]
 theorem toSingleAccept_sMTr_antiDerivative_isSome {a : εNA.FinAcc State Symbol}

--- a/Cslib/Computability/Automata/NA/BuchiInter.lean
+++ b/Cslib/Computability/Automata/NA/BuchiInter.lean
@@ -69,8 +69,7 @@ lemma inter_freq_acc_freq_acc {xs : ωSequence Symbol} {ss : ωSequence ((Π i, 
   have (k : ℕ) := (h_run.trans k).right
   apply frequently_leadsTo_frequently h_inf
   apply leadsTo_trans (q := {s | s.snd = !i})
-  · apply step_leadsTo
-    grind
+  · grind
   · apply until_frequently_not_leadsTo
     · grind
     · apply Frequently.mono h_inf

--- a/Cslib/Computability/Automata/NA/Loop.lean
+++ b/Cslib/Computability/Automata/NA/Loop.lean
@@ -160,10 +160,7 @@ theorem loop_language_eq [Inhabited Symbol] :
     use ss, h_run
     apply frequently_iff_strictMono.mpr
     use xls.cumLen, ?_, by grind
-    apply cumLen_strictMono
-    intro k
-    apply List.length_pos_iff.mpr
-    grind
+    grind [cumLen_strictMono, List.length_pos_iff]
 
 end Buchi
 
@@ -195,9 +192,7 @@ theorem loop_language_eq [Inhabited Symbol] (h : ¬ language na = 0) :
         use s0
       obtain ⟨xs, ss, h_ωtr, rfl, rfl⟩ := LTS.Total.extend_omegaExecution h_mtr
       have h_run : na.finLoop.Run (xl ++ω xs) ss := by grind [Run]
-      obtain ⟨h1, h2⟩ : 0 < xl.length ∧ (ss xl.length).isLeft := by
-        simp only [mem_singleton_iff] at h_acc
-        grind
+      obtain ⟨h1, h2⟩ : 0 < xl.length ∧ (ss xl.length).isLeft := by grind
       obtain ⟨n, h_n, h_take, h_drop, h_ωtr'⟩ := loop_run_one_iter h_run h1 h2
       left; refine ⟨xl.take n, ?_, xl.drop n, ?_, ?_⟩
       · #adaptation_note

--- a/Cslib/Computability/Distributed/FLP/FairScheduler.lean
+++ b/Cslib/Computability/Distributed/FLP/FairScheduler.lean
@@ -231,7 +231,6 @@ theorem fair_omegaExecution {d : DeliverMsg P M S} {ps : Set P} {q : State P M S
     grind [fair_fairSegs hd s0 hs0]
   obtain ⟨ss, _, _, _⟩ := flatten_fairSegs hmtr hpos hsch
   have : ss 0 = s0 := by grind [fairScheduler_init]
-  use ss
   grind
 
 /-- If `d.ForallActions r`, then the concatenation of all `a.fairSegActions d ps s0` segments

--- a/Cslib/Computability/URM/Execution.lean
+++ b/Cslib/Computability/URM/Execution.lean
@@ -161,8 +161,6 @@ theorem eq_of_halts {init s₁ s₂ : State}
   -- But s₁ and s₂ are normal forms, so w must equal both
   have hn1 := isHalted_iff_normal.mp hh1
   have hn2 := isHalted_iff_normal.mp hh2
-  obtain ⟨pc₁, regs₁⟩ := s₁
-  obtain ⟨pc₂, regs₂⟩ := s₂
   grind
 
 end Steps

--- a/Cslib/Foundations/Relation/Domain.lean
+++ b/Cslib/Foundations/Relation/Domain.lean
@@ -49,8 +49,7 @@ lemma cod_empty : cod (emptyHRelation : α → β → Prop) = ∅ := by grind
 @[simp, grind =]
 lemma dom_eq_empty_iff : dom r = ∅ ↔ r = emptyHRelation where
   mp h := by
-    ext a b
-    simp
+    ext a
     grind => have : a ∈ dom r; finish
   mpr := by grind
 
@@ -58,7 +57,6 @@ lemma dom_eq_empty_iff : dom r = ∅ ↔ r = emptyHRelation where
 lemma cod_eq_empty_iff : cod r = ∅ ↔ r = emptyHRelation where
   mp h := by
     ext a b
-    simp
     grind => have : b ∈ cod r; finish
   mpr h := by grind
 

--- a/Cslib/Foundations/Semantics/LTS/Bisimulation.lean
+++ b/Cslib/Foundations/Semantics/LTS/Bisimulation.lean
@@ -436,7 +436,6 @@ theorem Bisimilarity.bisimilarity_neq_traceEq :
     ∃ (State : Type) (Label : Type) (lts : LTS State Label),
       HomBisimilarity lts ≠ HomTraceEq lts := by
   obtain ⟨State, Label, lts, h⟩ := IsBisimulation.traceEq_not_bisim
-  use State, Label, lts
   grind [Bisimilarity.isBisimulation lts lts]
 
 /-- In any deterministic LTS, trace equivalence is a bisimulation. -/

--- a/Cslib/Foundations/Semantics/LTS/OmegaExecution.lean
+++ b/Cslib/Foundations/Semantics/LTS/OmegaExecution.lean
@@ -87,8 +87,6 @@ theorem OmegaExecution.flatten_execution [Inhabited Label]
     have := segment_lower_bound h_mono h_zero n
     by_cases h_n : n + 1 < segs.cumLen (segment segs.cumLen n + 1)
     · have := segment_range_val h_mono (by grind) h_n
-      have : n + 1 - segs.cumLen (segment segs.cumLen n) < (μls (segment segs.cumLen n)).length :=
-        by grind
       grind
     · have h1 : segs.cumLen (segment segs.cumLen n + 1) = n + 1 := by
         grind [segment_upper_bound h_mono h_zero n]

--- a/Cslib/Foundations/Semantics/LTS/TraceEq.lean
+++ b/Cslib/Foundations/Semantics/LTS/TraceEq.lean
@@ -115,7 +115,6 @@ scoped notation s:max " ~tr[" lts "] " s':max => HomTraceEq lts s s'
 @[refl] theorem HomTraceEq.refl (s : State) : s ~tr[lts] s := rfl
 
 @[simp] theorem TraceEq.flip_eq : flip (TraceEq lts₁ lts₂) = TraceEq lts₂ lts₁ := by
-  ext s₁ s₂
   grind [flip, TraceEq]
 
 /-- Trace equivalence is symmetric. -/

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/BetaAt.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/BetaAt.lean
@@ -97,7 +97,6 @@ lemma countRedexes_app_le (M N : Term Var) :
 /-- An application with an abstraction operator has one more redex than its parts. -/
 lemma countRedexes_app_abs {M : Term Var} (ha : IsAbs M) (N : Term Var) :
     countRedexes (app M N) = countRedexes M + countRedexes N + 1 := by
-  cases ha
   grind
 
 /-- Contracting a redex of an abstraction yields an abstraction. -/

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullBeta.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullBeta.lean
@@ -86,7 +86,7 @@ lemma steps_lc_or_rfl {M M' : Term Var} (redex : M ↠βᶠ M') : (LC M ∧ LC M
 lemma redex_subst_cong_lc (s s' t : Term Var) (x : Var) (step : s ⭢βᶠ s') (h_lc : LC t) :
     s[x := t] ⭢βᶠ s'[x := t] := by
   induction step with
-  | base beta => cases beta; grind [subst_open]
+  | base beta => grind [subst_open]
   | abs  => grind [Xi.abs <| free_union Var]
   | _ => grind
 

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullEta.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/FullEta.lean
@@ -127,10 +127,7 @@ lemma step_subst_cong_r {x : Var} (s t t' : Term Var) (st : t ⭢ηᶠ t') (lc_s
     · exact redex_app_r_cong (ih_r t t' st) (subst_lc hl (step_lc_r st))
   | abs L body h_lc_body ih =>
     apply redex_abs_cong (L ∪ {x})
-    · intro z
-      grind =>
-        have : (body ^ fvar z)[x := t] ↠ηᶠ (body ^ fvar z)[x := t']
-        finish
+    · grind
 
 /- `steps_subst_cong_r` can be generalized to multiple reductions `t ↠ηᶠ t'`. -/
 lemma steps_subst_cong_r {x : Var} (s t t' : Term Var) (st : t ↠ηᶠ t') (lc_s : LC s) :

--- a/Cslib/Languages/LambdaCalculus/Named/Untyped/Properties.lean
+++ b/Cslib/Languages/LambdaCalculus/Named/Untyped/Properties.lean
@@ -421,7 +421,6 @@ private lemma subst.abs_fresh_helper {m r : Term Var} {x y z : Var} :
               Finset.union_singleton, AlphaEquiv_def]
           let s := (insert x (insert y (m.vars ∪ r.vars)))
           have hw := fresh_notMem s
-          set w := fresh s
           grind [AlphaEquiv.refl, AlphaEquiv.trans, vars_either_fv_or_bv]
         · grind
     grind

--- a/Cslib/Logics/HML/LogicalEquivalence.lean
+++ b/Cslib/Logics/HML/LogicalEquivalence.lean
@@ -94,7 +94,6 @@ instance (lts : LTS State Label) :
       grind [=_ Proposition.Context.fill_def]
     case not c ih | andL c ih | andR c ih =>
       intro s
-      specialize ih s
       grind [=_ Proposition.Context.fill_def]
     case diamond c ih =>
       intro s

--- a/Cslib/Logics/LinearLogic/CLL/PhaseSemantics/Basic.lean
+++ b/Cslib/Logics/LinearLogic/CLL/PhaseSemantics/Basic.lean
@@ -315,10 +315,7 @@ lemma inter_eq_orth_union_orth (G H : Fact P) :
   constructor
   · simp only [orthogonal_def, mem_union]
     grind
-  · intro _
-    have : m ∈ ((G : Set P)⫠⫠) := by grind
-    have : m ∈ ((H : Set P)⫠⫠) := by grind
-    grind [Fact.eq]
+  · grind [Fact.eq]
 
 instance : Min (Fact P) where
   min G H := Fact.mkDual (G ∩ H) (G⫠ ∪ H⫠) <| by simp

--- a/Cslib/Logics/Modal/Basic.lean
+++ b/Cslib/Logics/Modal/Basic.lean
@@ -280,7 +280,6 @@ theorem Satisfies.b_symm (r : World → World → Prop) [Nonempty Atom]
     have a := Classical.arbitrary Atom
     let v₁ := fun (w' : World) (a : Atom) => w' = w₁
     let h₁ := h (v := v₁) (w := w₁) (φ := a)
-    simp [imp_iff_imp] at h₁
     grind
 
 /-- The 4 axiom, valid for all transitive models. -/

--- a/Cslib/Logics/Modal/Denotation.lean
+++ b/Cslib/Logics/Modal/Denotation.lean
@@ -53,8 +53,7 @@ theorem Proposition.equiv_iff_denotation_eq :
     (φ₁ ≡[Equiv m] φ₂) ↔ φ₁.denotation m = φ₂.denotation m := by
   constructor <;> intro h
   case mp =>
-    ext w
-    grind [h w]
+    grind
   case mpr =>
     intro w
     rw [Set.ext_iff] at h


### PR DESCRIPTION
Merging some tactics with subsequent `grind`s as suggested by the linter.

Verified that the compilation time does not increase substantially.