### PR TITLE
chore(LTS/MapHom): golf mapHom_mTr proof

### DIFF
--- a/Cslib/Foundations/Semantics/LTS/MapHom.lean
+++ b/Cslib/Foundations/Semantics/LTS/MapHom.lean
@@ -48,8 +48,7 @@ theorem mapHom_mTr {lts : LTS State Label₁} {μs : List Label₂} :
   | cons μ μs ih =>
     rw [Hom.map_cons]
     apply Iff.intro .. <;> intro h
-    · obtain ⟨_, _, _⟩ := MTr.cons_iff.mp h
-      grind [mapHom_tr, MTr.append_iff (lts := lts)]
+    · grind [mapHom_tr, MTr.append_iff (lts := lts)]
     · obtain ⟨_, _, _⟩ := (MTr.append_iff (lts := lts)).mp h
       grind [mapHom_tr, MTr.cons_iff (lts := lts.mapHom f)]
 


### PR DESCRIPTION
Drop an `obtain` that the following `grind` does not need, as flagged by [the weekly `mergeWithGrind` report](https://leanprover.zulipchat.com/#narrow/channel/513188-CSLib/topic/Weekly.20linting.20log/near/620201866).