### PR TITLE
chore(HML/LogicalEquivalence): golf to remove `mergeWithGrind` opt

### DIFF
--- a/Cslib/Logics/HML/LogicalEquivalence.lean
+++ b/Cslib/Logics/HML/LogicalEquivalence.lean
@@ -85,8 +85,6 @@ instance : IsEquiv (Proposition Label) (Proposition.Equiv lts) := by
   rw [← equivalence_iff_isEquiv]
   grind [Equivalence, Proposition.Equiv]
 
--- Merging the `specialize` into `grind` breaks the other goal under `all_goals`.
-set_option linter.tacticAnalysis.mergeWithGrind false in
 /-- Logical equivalence is a lawful congruence. -/
 instance (lts : LTS State Label) :
     LawfulCongruence (Proposition.Equiv lts) where
@@ -101,8 +99,8 @@ instance (lts : LTS State Label) :
       intro s
       rw [Satisfies.iff_iff_iff]
       apply Iff.intro
-      all_goals
-        rintro ⟨w', h⟩
+      · grind [=_ Proposition.Context.fill_def]
+      · rintro ⟨w', h⟩
         specialize ih w'
         grind [=_ Proposition.Context.fill_def]
 


### PR DESCRIPTION
Golf a heavy proof that was recently flagged as such (in #850) by splitting `all_goals` into bullets and doing the work.