### PR TITLE
feat: add monad-polymorphic sorts

### DIFF
--- a/Cslib.lean
+++ b/Cslib.lean
@@ -2,6 +2,8 @@ module  -- shake: keep-all --deprecated_module: ignore
 
 public import Cslib.Algorithms.CCS.VendingMachine
 public import Cslib.Algorithms.Lean.MergeSort.MergeSort
+public import Cslib.Algorithms.Lean.Sort.Insertion
+public import Cslib.Algorithms.Lean.Sort.Merge
 public import Cslib.Algorithms.Lean.TimeM
 public import Cslib.Computability.Automata.Acceptors.Acceptor
 public import Cslib.Computability.Automata.Acceptors.OmegaAcceptor

--- a/Cslib/Algorithms/Lean/MergeSort/MergeSort.lean
+++ b/Cslib/Algorithms/Lean/MergeSort/MergeSort.lean
@@ -7,6 +7,8 @@ Authors: Sorrachai Yingchareonthawornhcai
 module
 
 public import Cslib.Algorithms.Lean.TimeM
+public import Cslib.Algorithms.Lean.Sort.Merge
+import all Cslib.Algorithms.Lean.Sort.Merge
 public import Mathlib.Data.Nat.Cast.Order.Ring
 public import Mathlib.Order.Lattice.Nat
 public import Mathlib.Data.Nat.Log
@@ -33,20 +35,10 @@ namespace Cslib.Algorithms.Lean.TimeM
 
 variable {α : Type} [LinearOrder α]
 
--- TODO: replace this with `List.mergeM`
 /-- Merges two lists into a single list, counting comparisons as time cost.
 Returns a `TimeM ℕ (List α)` where the time represents the number of comparisons performed. -/
-def merge :  List α → List α → TimeM ℕ (List α)
-  | [], ys => return ys
-  | xs, [] => return xs
-  | x::xs', y::ys' => do
-    ✓ let c := (x ≤ y : Bool)
-    if c then
-      let rest ← merge xs' (y::ys')
-      return (x :: rest)
-    else
-      let rest ← merge (x::xs') ys'
-      return (y :: rest)
+def merge (xs ys : List α) : TimeM ℕ (List α) :=
+  List.mergeM xs ys fun x y => do ✓ return x ≤ y
 
 -- TODO: replace this with `List.mergeSortM`
 /-- Sorts a list using the merge sort algorithm, counting comparisons as time cost.
@@ -68,7 +60,8 @@ open List
 /-- Our merge computes the one already in mathlib. -/
 @[simp, grind =]
 theorem ret_merge (xs ys : List α) : ⟪merge xs ys⟫ = xs.merge ys := by
-  fun_induction merge with grind [nil_merge, merge_right, cons_merge_cons]
+  unfold merge
+  fun_induction mergeM with grind [nil_merge, merge_right, cons_merge_cons]
 
 /-- A list is sorted if it satisfies the `Pairwise (· ≤ ·)` predicate. -/
 abbrev IsSorted (l : List α) : Prop := List.Pairwise (· ≤ ·) l
@@ -95,7 +88,8 @@ theorem mergeSort_sorted (xs : List α) : IsSorted ⟪mergeSort xs⟫ := by
   | case2 _ _ _ _ _ ih2 ih1 => exact sorted_merge ih2 ih1
 
 lemma merge_perm (l₁ l₂ : List α) : ⟪merge l₁ l₂⟫ ~ l₁ ++ l₂ := by
-  fun_induction merge with grind [List.merge_perm_append]
+  unfold merge
+  fun_induction mergeM with grind [List.merge_perm_append]
 
 theorem mergeSort_perm (xs : List α) : ⟪mergeSort xs⟫ ~ xs := by
   fun_induction mergeSort xs with
@@ -181,7 +175,8 @@ theorem merge_ret_length_eq_sum (xs ys : List α) :
   · grind [List.length_merge]
 
 @[simp] theorem merge_time (xs ys : List α) : (merge xs ys).time ≤ xs.length + ys.length := by
-  fun_induction merge with
+  unfold merge
+  fun_induction List.mergeM with
   | case3 =>
     grind
   | _ => simp

--- a/Cslib/Algorithms/Lean/MergeSort/MergeSort.lean
+++ b/Cslib/Algorithms/Lean/MergeSort/MergeSort.lean
@@ -33,6 +33,7 @@ namespace Cslib.Algorithms.Lean.TimeM
 
 variable {α : Type} [LinearOrder α]
 
+-- TODO: replace this with `List.mergeM`
 /-- Merges two lists into a single list, counting comparisons as time cost.
 Returns a `TimeM ℕ (List α)` where the time represents the number of comparisons performed. -/
 def merge :  List α → List α → TimeM ℕ (List α)
@@ -47,6 +48,7 @@ def merge :  List α → List α → TimeM ℕ (List α)
       let rest ← merge (x::xs') ys'
       return (y :: rest)
 
+-- TODO: replace this with `List.mergeSortM`
 /-- Sorts a list using the merge sort algorithm, counting comparisons as time cost.
 Returns a `TimeM ℕ (List α)` where the time represents the total number of comparisons. -/
 def mergeSort (xs : List α) : TimeM ℕ (List α) :=  do

--- a/Cslib/Algorithms/Lean/MergeSort/MergeSort.lean
+++ b/Cslib/Algorithms/Lean/MergeSort/MergeSort.lean
@@ -33,25 +33,37 @@ set_option autoImplicit false
 
 namespace Cslib.Algorithms.Lean.TimeM
 
-variable {α : Type} [LinearOrder α]
+variable {α : Type}
+
+open List in
+/-- `TimeM.ret` passes through `List.mergeM` into the comparator. -/
+@[simp, grind =]
+theorem ret_mergeM {T} [AddMonoid T] (xs ys : List α) (le : α → α → TimeM T Bool) :
+    ⟪List.mergeM xs ys le⟫ = List.merge xs ys (fun x y => ⟪le x y⟫) := by
+  fun_induction merge with grind [mergeM, nil_merge, merge_right, cons_merge_cons]
+
+open List in
+/-- `TimeM.ret` passes through `List.mergeSortM` into the comparator. -/
+@[simp]
+theorem ret_mergeSortM {T} [AddMonoid T] (xs : List α) (le : α → α → TimeM T Bool) :
+    ⟪List.mergeSortM xs le⟫ = List.mergeSort xs (fun x y => ⟪le x y⟫) := by
+  fun_induction List.mergeSortM with
+  | case1 | case2 => simp
+  | case3 a b xs le _ _ _ iha ihb =>
+    simp only [ret_bind, ret_mergeM, mergeSort]
+    rw [iha, ihb]
+
+variable [LinearOrder α]
 
 /-- Merges two lists into a single list, counting comparisons as time cost.
 Returns a `TimeM ℕ (List α)` where the time represents the number of comparisons performed. -/
-def merge (xs ys : List α) : TimeM ℕ (List α) :=
+abbrev merge (xs ys : List α) : TimeM ℕ (List α) :=
   List.mergeM xs ys fun x y => do ✓ return x ≤ y
 
--- TODO: replace this with `List.mergeSortM`
 /-- Sorts a list using the merge sort algorithm, counting comparisons as time cost.
 Returns a `TimeM ℕ (List α)` where the time represents the total number of comparisons. -/
-def mergeSort (xs : List α) : TimeM ℕ (List α) :=  do
-  if xs.length < 2 then return xs
-  else
-    let half  := xs.length / 2
-    let left  := xs.take half
-    let right := xs.drop half
-    let sortedLeft  ← mergeSort left
-    let sortedRight ← mergeSort right
-    merge sortedLeft sortedRight
+abbrev mergeSort (xs : List α) : TimeM ℕ (List α) :=
+  List.mergeSortM xs fun x y => do ✓ return x ≤ y
 
 section Correctness
 
@@ -82,25 +94,16 @@ theorem sorted_merge {l1 l2 : List α} (hxs : IsSorted l1) (hys : IsSorted l2) :
   grind [hxs.merge hys]
 
 theorem mergeSort_sorted (xs : List α) : IsSorted ⟪mergeSort xs⟫ := by
-  fun_induction mergeSort xs with
-  | case1 x =>
-    rcases x with _ | ⟨a, _ | ⟨b, rest⟩⟩ <;> grind
-  | case2 _ _ _ _ _ ih2 ih1 => exact sorted_merge ih2 ih1
+  unfold mergeSort
+  simp only [bind_pure_comp, ret_mergeSortM, ret_map]
+  convert List.pairwise_mergeSort ?_ ?_ ?_ <;> grind
 
 lemma merge_perm (l₁ l₂ : List α) : ⟪merge l₁ l₂⟫ ~ l₁ ++ l₂ := by
   unfold merge
   fun_induction mergeM with grind [List.merge_perm_append]
 
 theorem mergeSort_perm (xs : List α) : ⟪mergeSort xs⟫ ~ xs := by
-  fun_induction mergeSort xs with
-  | case1 => simp
-  | case2 x _ _ left right ih2 ih1 =>
-    simp only [ret_bind]
-    calc
-      ⟪merge ⟪mergeSort left⟫ ⟪mergeSort right⟫⟫  ~
-      ⟪mergeSort left⟫ ++ ⟪mergeSort right⟫  := by apply merge_perm
-      _ ~ left++right := Perm.append ih2 ih1
-      _ ~ x := by simp only [take_append_drop, Perm.refl, left, right]
+  simpa using List.mergeSort_perm _ _
 
 /-- MergeSort is functionally correct. -/
 theorem mergeSort_correct (xs : List α) : IsSorted ⟪mergeSort xs⟫ ∧ ⟪mergeSort xs⟫ ~ xs :=
@@ -170,23 +173,21 @@ theorem merge_ret_length_eq_sum (xs ys : List α) :
 
 @[simp] theorem mergeSort_same_length (xs : List α) :
     ⟪mergeSort xs⟫.length = xs.length := by
-  fun_induction mergeSort
-  · simp
-  · grind [List.length_merge]
+  simp
 
 @[simp] theorem merge_time (xs ys : List α) : (merge xs ys).time ≤ xs.length + ys.length := by
   unfold merge
-  fun_induction List.mergeM with
-  | case3 =>
-    grind
-  | _ => simp
+  fun_induction List.mergeM with grind
 
 theorem mergeSort_time_le (xs : List α) :
     (mergeSort xs).time ≤ timeMergeSortRec xs.length := by
-  fun_induction mergeSort with
-  | case1 =>
+  unfold mergeSort
+  generalize hle' : (fun x y : α => _) = le'
+  fun_induction List.mergeSortM with
+  | case1 | case2 =>
     grind
-  | case2 _ _ _ _ _ ih2 ih1 =>
+  | case3 _ _ _ _ _ ih2 ih1 =>
+    subst hle'
     simp only [time_bind]
     grw [merge_time]
     simp only [mergeSort_same_length]

--- a/Cslib/Algorithms/Lean/MergeSort/MergeSort.lean
+++ b/Cslib/Algorithms/Lean/MergeSort/MergeSort.lean
@@ -70,10 +70,8 @@ section Correctness
 open List
 
 /-- Our merge computes the one already in mathlib. -/
-@[simp, grind =]
 theorem ret_merge (xs ys : List α) : ⟪merge xs ys⟫ = xs.merge ys := by
-  unfold merge
-  fun_induction mergeM with grind [nil_merge, merge_right, cons_merge_cons]
+  simp
 
 /-- A list is sorted if it satisfies the `Pairwise (· ≤ ·)` predicate. -/
 abbrev IsSorted (l : List α) : Prop := List.Pairwise (· ≤ ·) l

--- a/Cslib/Algorithms/Lean/MergeSort/MergeSort.lean
+++ b/Cslib/Algorithms/Lean/MergeSort/MergeSort.lean
@@ -171,7 +171,7 @@ theorem merge_ret_length_eq_sum (xs ys : List α) :
     ⟪merge xs ys⟫.length = xs.length + ys.length := by
   simp
 
-@[simp] theorem mergeSort_same_length (xs : List α) :
+theorem mergeSort_same_length (xs : List α) :
     ⟪mergeSort xs⟫.length = xs.length := by
   simp
 

--- a/Cslib/Algorithms/Lean/MergeSort/MergeSort.lean
+++ b/Cslib/Algorithms/Lean/MergeSort/MergeSort.lean
@@ -49,7 +49,7 @@ theorem ret_mergeSortM {T} [AddMonoid T] (xs : List α) (le : α → α → Time
     ⟪List.mergeSortM xs le⟫ = List.mergeSort xs (fun x y => ⟪le x y⟫) := by
   fun_induction List.mergeSortM with
   | case1 | case2 => simp
-  | case3 a b xs le _ _ _ iha ihb =>
+  | case3 a b xs le iha ihb =>
     simp only [ret_bind, ret_mergeM, mergeSort]
     rw [iha, ihb]
 
@@ -94,13 +94,10 @@ theorem sorted_merge {l1 l2 : List α} (hxs : IsSorted l1) (hys : IsSorted l2) :
   grind [hxs.merge hys]
 
 theorem mergeSort_sorted (xs : List α) : IsSorted ⟪mergeSort xs⟫ := by
-  unfold mergeSort
-  simp only [bind_pure_comp, ret_mergeSortM, ret_map]
-  convert List.pairwise_mergeSort ?_ ?_ ?_ <;> grind
+  simpa using List.pairwise_mergeSort' _ xs
 
 lemma merge_perm (l₁ l₂ : List α) : ⟪merge l₁ l₂⟫ ~ l₁ ++ l₂ := by
-  unfold merge
-  fun_induction mergeM with grind [List.merge_perm_append]
+  simpa using List.merge_perm_append _
 
 theorem mergeSort_perm (xs : List α) : ⟪mergeSort xs⟫ ~ xs := by
   simpa using List.mergeSort_perm _ _
@@ -182,12 +179,10 @@ theorem merge_ret_length_eq_sum (xs ys : List α) :
 theorem mergeSort_time_le (xs : List α) :
     (mergeSort xs).time ≤ timeMergeSortRec xs.length := by
   unfold mergeSort
-  generalize hle' : (fun x y : α => _) = le'
   fun_induction List.mergeSortM with
   | case1 | case2 =>
     grind
-  | case3 _ _ _ _ _ ih2 ih1 =>
-    subst hle'
+  | case3 _ _ _ _ ih2 ih1 =>
     simp only [time_bind]
     grw [merge_time]
     simp only [mergeSort_same_length]

--- a/Cslib/Algorithms/Lean/Sort/Insertion.lean
+++ b/Cslib/Algorithms/Lean/Sort/Insertion.lean
@@ -4,7 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Eric Wieser
 -/
 module
+
 public import Mathlib.Data.List.Sort
+
+import Cslib.Init
 
 /-!
 # A Monadic version of the builtin `List.insertionSort`

--- a/Cslib/Algorithms/Lean/Sort/Insertion.lean
+++ b/Cslib/Algorithms/Lean/Sort/Insertion.lean
@@ -1,0 +1,54 @@
+/-
+Copyright (c) 2016 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad, Eric Wieser
+-/
+module
+public import Mathlib.Data.List.Sort
+
+/-!
+# A Monadic version of the builtin `List.insertionSort`
+
+This can be instantiated with `Id` to recover the original, or with `TimeM` or `FreeM` for
+algorithmic analysis.
+-/
+
+public section
+
+namespace List
+
+variable {m} [Monad m] (r : α → α → m Bool)
+
+/-- A monadic version of `List.orderedInsert`. -/
+def orderedInsertM (a : α) : List α → m (List α)
+  | [] => return [a]
+  | b :: l => do if ← r a b then return a :: b :: l else return b :: (← orderedInsertM a l)
+
+@[simp]
+theorem orderedInsertM_pure [LawfulMonad m] (r : α → α → Bool) (a : α) (xs : List α) :
+    orderedInsertM (fun x y => (pure (r x y) : m Bool)) a xs =
+      pure (orderedInsert (r · ·) a xs) := by
+  fun_induction orderedInsertM with grind [orderedInsertM]
+
+@[simp]
+theorem idRun_orderedInsertM (r : α → α → Id Bool) (a : α) (xs : List α) :
+    Id.run (orderedInsertM r a xs) = orderedInsert (fun x y => Id.run <| r x y) a xs :=
+  orderedInsertM_pure _ _ _
+
+/-- A monadic version of `List.insertionSort`. -/
+@[simp]
+def insertionSortM : List α → m (List α)
+  | [] => return []
+  | b :: l => do orderedInsertM r b (← insertionSortM l)
+
+@[simp]
+theorem insertionSortM_pure [LawfulMonad m] (xs : List α) (r : α → α → Bool) :
+    insertionSortM (fun x y => (pure (r x y) : m Bool)) xs = pure (insertionSort (r · ·) xs) := by
+  fun_induction insertionSortM with simp_all
+
+@[simp]
+theorem idRun_insertionSortM (xs : List α) (r : α → α → Id Bool) :
+    Id.run (insertionSortM r xs) = insertionSort (fun x y => Id.run <| r x y) xs :=
+  insertionSortM_pure _ _
+
+end List

--- a/Cslib/Algorithms/Lean/Sort/Insertion.lean
+++ b/Cslib/Algorithms/Lean/Sort/Insertion.lean
@@ -27,6 +27,13 @@ def orderedInsertM (a : α) : List α → m (List α)
   | [] => return [a]
   | b :: l => do if ← r a b then return a :: b :: l else return b :: (← orderedInsertM a l)
 
+@[simp] theorem orderedInsertM_nil (a : α) : orderedInsertM r a [] = pure [a] := by
+  rfl
+@[simp] theorem orderedInsertM_cons (a b : α) (l : List α) :
+    orderedInsertM r a (b :: l) = do
+      if ← r a b then return a :: b :: l else return b :: (← orderedInsertM r a l) := by
+  rfl
+
 @[simp]
 theorem orderedInsertM_pure [LawfulMonad m] (r : α → α → Bool) (a : α) (xs : List α) :
     orderedInsertM (fun x y => (pure (r x y) : m Bool)) a xs =
@@ -39,10 +46,15 @@ theorem idRun_orderedInsertM (r : α → α → Id Bool) (a : α) (xs : List α)
   orderedInsertM_pure _ _ _
 
 /-- A monadic version of `List.insertionSort`. -/
-@[simp]
 def insertionSortM : List α → m (List α)
   | [] => return []
   | b :: l => do orderedInsertM r b (← insertionSortM l)
+
+@[simp] theorem insertionSortM_nil : insertionSortM r [] = pure [] := by
+  rfl
+@[simp] theorem insertionSortM_cons (b : α) (l : List α) :
+    insertionSortM r (b :: l) = (do orderedInsertM r b (← insertionSortM r l)) := by
+  rfl
 
 @[simp]
 theorem insertionSortM_pure [LawfulMonad m] (xs : List α) (r : α → α → Bool) :

--- a/Cslib/Algorithms/Lean/Sort/Insertion.lean
+++ b/Cslib/Algorithms/Lean/Sort/Insertion.lean
@@ -10,7 +10,7 @@ public import Mathlib.Data.List.Sort
 import Cslib.Init
 
 /-!
-# A Monadic version of the builtin `List.insertionSort`
+# A Monadic version of Mathlib's `List.insertionSort`
 
 This can be instantiated with `Id` to recover the original, or with `TimeM` or `FreeM` for
 algorithmic analysis.

--- a/Cslib/Algorithms/Lean/Sort/Merge.lean
+++ b/Cslib/Algorithms/Lean/Sort/Merge.lean
@@ -4,7 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison, Eric Wieser
 -/
 module
+
 import all Init.Data.List.Sort.Basic
+
+import Cslib.Init
 
 /-!
 # A Monadic version of the builtin `List.mergeSort`

--- a/Cslib/Algorithms/Lean/Sort/Merge.lean
+++ b/Cslib/Algorithms/Lean/Sort/Merge.lean
@@ -1,0 +1,77 @@
+/-
+Copyright (c) 2024 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison, Eric Wieser
+-/
+module
+import all Init.Data.List.Sort.Basic
+
+/-!
+# A Monadic version of the builtin `List.mergeSort`
+
+This can be instantiated with `Id` to recover the original, or with `TimeM` or `FreeM` for
+algorithmic analysis.
+-/
+
+public section
+
+namespace List
+
+variable {m} [Monad m]
+
+/-- A monadic version of `List.merge` -/
+def mergeM (xs ys : List α) (le : α → α → m Bool) : m (List α) := do
+  match xs, ys with
+  | [], ys => return ys
+  | xs, [] => return xs
+  | x :: xs, y :: ys =>
+    if ← le x y then
+      return x :: (← mergeM xs (y :: ys) le)
+    else
+      return y :: (← mergeM (x :: xs) ys le)
+
+@[simp] theorem nil_mergeM (ys : List α) (le : α → α → m Bool) : mergeM [] ys le = pure ys := by
+  simp [mergeM]
+@[simp] theorem mergeM_right (xs : List α) (le : α → α → m Bool) : mergeM xs [] le = pure xs := by
+  induction xs with
+  | nil => simp
+  | cons x xs ih => simp [mergeM]
+
+@[simp]
+theorem mergeM_pure [LawfulMonad m] (xs ys : List α) (le : α → α → Bool) :
+    mergeM xs ys (fun x y => (pure (le x y) : m Bool)) = pure (merge xs ys le) := by
+  fun_induction mergeM with grind [merge]
+
+@[simp]
+theorem idRun_mergeM (xs ys : List α) (le : α → α → Id Bool) :
+    Id.run (mergeM xs ys le) = merge xs ys (fun x y => Id.run <| le x y) :=
+  mergeM_pure _ _ _
+
+set_option linter.unusedVariables false in
+/-- A monadic version of `List.mergeSortM` -/
+def mergeSortM : ∀ (xs : List α) (le : α → α → m Bool), m (List α)
+  | [], _ => return []
+  | [a], _ => return [a]
+  | a :: b :: xs, le => do
+    let lr := MergeSort.Internal.splitInTwo ⟨a :: b :: xs, rfl⟩
+    have := by simpa using lr.2.2
+    have := by simpa using lr.1.2
+    mergeM (← mergeSortM lr.1 le) (← mergeSortM lr.2 le) le
+termination_by xs => xs.length
+
+@[simp]
+theorem mergeSortM_pure [LawfulMonad m] (xs : List α) (le : α → α → Bool) :
+    mergeSortM xs (fun x y => (pure (le x y) : m Bool)) = pure (mergeSort xs le) := by
+  fun_induction mergeSort with
+  | case1 | case2 => simp [mergeSortM]
+  | case3  a b xs le lr _ _ ih1 ih2 =>
+    simp only [mergeSortM]
+    rw [ih1, ih2]
+    simp
+
+@[simp]
+theorem idRun_mergeSortM (xs : List α) (le : α → α → Id Bool) :
+    Id.run (mergeSortM xs le) = mergeSort xs (fun x y => Id.run <| le x y) :=
+  mergeSortM_pure _ _
+
+end List

--- a/Cslib/Algorithms/Lean/Sort/Merge.lean
+++ b/Cslib/Algorithms/Lean/Sort/Merge.lean
@@ -40,7 +40,7 @@ def mergeM (xs ys : List α) (le : α → α → m Bool) : m (List α) := do
   | nil => simp
   | cons x xs ih => simp [mergeM]
 
-@[simp]
+@[simp↓]
 theorem mergeM_pure [LawfulMonad m] (xs ys : List α) (le : α → α → Bool) :
     mergeM xs ys (fun x y => (pure (le x y) : m Bool)) = pure (merge xs ys le) := by
   fun_induction mergeM with grind [merge]
@@ -50,19 +50,17 @@ theorem idRun_mergeM (xs ys : List α) (le : α → α → Id Bool) :
     Id.run (mergeM xs ys le) = merge xs ys (fun x y => Id.run <| le x y) :=
   mergeM_pure _ _ _
 
-set_option linter.unusedVariables false in
 /-- A monadic version of `List.mergeSortM` -/
-def mergeSortM : ∀ (xs : List α) (le : α → α → m Bool), m (List α)
-  | [], _ => return []
-  | [a], _ => return [a]
-  | a :: b :: xs, le => do
+def mergeSortM (xs : List α) (le : α → α → m Bool) : m (List α) :=
+  match xs with
+  | [] => return []
+  | [a] => return [a]
+  | a :: b :: xs => do
     let lr := MergeSort.Internal.splitInTwo ⟨a :: b :: xs, rfl⟩
-    have := by simpa using lr.2.2
-    have := by simpa using lr.1.2
     mergeM (← mergeSortM lr.1 le) (← mergeSortM lr.2 le) le
-termination_by xs => xs.length
+termination_by xs.length
 
-@[simp]
+@[simp↓]
 theorem mergeSortM_pure [LawfulMonad m] (xs : List α) (le : α → α → Bool) :
     mergeSortM xs (fun x y => (pure (le x y) : m Bool)) = pure (mergeSort xs le) := by
   fun_induction mergeSort with

--- a/Cslib/Algorithms/Lean/Sort/Merge.lean
+++ b/Cslib/Algorithms/Lean/Sort/Merge.lean
@@ -51,7 +51,7 @@ theorem idRun_mergeM (xs ys : List α) (le : α → α → Id Bool) :
   mergeM_pure _ _ _
 
 set_option linter.unusedVariables false in
-/-- A monadic version of `List.mergeSortM` -/
+/-- A monadic version of `List.mergeSort` -/
 def mergeSortM : ∀ (xs : List α) (le : α → α → m Bool), m (List α)
   | [], _ => return []
   | [a], _ => return [a]

--- a/Cslib/Algorithms/Lean/Sort/Merge.lean
+++ b/Cslib/Algorithms/Lean/Sort/Merge.lean
@@ -39,6 +39,13 @@ def mergeM (xs ys : List α) (le : α → α → m Bool) : m (List α) := do
   induction xs with
   | nil => simp
   | cons x xs ih => simp [mergeM]
+@[simp] theorem cons_mergeM_cons (x y : α) (xs ys : List α) (le : α → α → m Bool) :
+    mergeM (x :: xs) (y :: ys) le = do
+      if ← le x y then
+        return x :: (← mergeM xs (y :: ys) le)
+      else
+        return y :: (← mergeM (x :: xs) ys le) := by
+  simp [mergeM]
 
 @[simp↓]
 theorem mergeM_pure [LawfulMonad m] (xs ys : List α) (le : α → α → Bool) :
@@ -60,12 +67,18 @@ def mergeSortM (xs : List α) (le : α → α → m Bool) : m (List α) :=
     mergeM (← mergeSortM lr.1 le) (← mergeSortM lr.2 le) le
 termination_by xs.length
 
+@[simp] theorem mergeSortM_nil (le : α → α → m Bool) : mergeSortM [] le = pure [] := by
+  simp [mergeSortM]
+@[simp] theorem mergeSortM_singleton (a : α) (le : α → α → m Bool) :
+    mergeSortM [a] le = pure [a] := by
+  simp [mergeSortM]
+
 @[simp↓]
 theorem mergeSortM_pure [LawfulMonad m] (xs : List α) (le : α → α → Bool) :
     mergeSortM xs (fun x y => (pure (le x y) : m Bool)) = pure (mergeSort xs le) := by
   fun_induction mergeSort with
-  | case1 | case2 => simp [mergeSortM]
-  | case3  a b xs le lr _ _ ih1 ih2 =>
+  | case1 | case2 => simp
+  | case3 a b xs le lr _ _ ih1 ih2 =>
     simp only [mergeSortM]
     rw [ih1, ih2]
     simp


### PR DESCRIPTION
These can be used to:
* replace the specialized timeM version (included in this PR)
* implement sorts that log as they sort
* specialize to FreeM or PFunctor.FreeM

The old copyright dates on these files are because they were written by directly copying the corresponding non-monadic code from mathlib / lean core.

As a general pattern, writing code monad generically, then specializing it, allows Lean's compiler to compile it efficiently in `Id`, but also allows it to be reasoned about for richer monads `m`. The alternative of starting with a rich monad like `FreeM` and transporting back to `Id` has two downsides:

* The algorithm itself must live inside CSLib, in order to have access to `FreeM`.
* The compiler must be able to fully optimize out `FreeM.liftM` / `TimeM.ret` to match performance characteristics.

If you have no intent of ever executing the code then these concerns don't matter all that much. For now, the main benefit to CSLib is that we can write the algorithms just once while exploring a zoo of computation models to evaluate them in.

As a bonus, this lets us reuse some proofs about `List.mergeSort`, reducing the length of some proofs.