### PR TITLE
feat(MultiTapeTM): add input and work tape rewinding

### DIFF
--- a/Cslib.lean
+++ b/Cslib.lean
@@ -47,11 +47,13 @@ public import Cslib.Computability.Languages.OmegaRegularLanguage
 public import Cslib.Computability.Languages.RegularLanguage
 public import Cslib.Computability.Languages.SafetyLiveness
 public import Cslib.Computability.Machines.Turing.MultiTape.Deterministic
+public import Cslib.Computability.Machines.Turing.MultiTape.NormalForms.RewindInput
 public import Cslib.Computability.Machines.Turing.MultiTape.Plumbing.Basic
 public import Cslib.Computability.Machines.Turing.MultiTape.Plumbing.ExtendTapes
 public import Cslib.Computability.Machines.Turing.MultiTape.Plumbing.InputFromWorkTape
 public import Cslib.Computability.Machines.Turing.MultiTape.Plumbing.InputFromWorkTape.Defs
 public import Cslib.Computability.Machines.Turing.MultiTape.Plumbing.OutputToWorkTape
+public import Cslib.Computability.Machines.Turing.MultiTape.Plumbing.Rewind
 public import Cslib.Computability.Machines.Turing.MultiTape.Plumbing.Sequential
 public import Cslib.Computability.Machines.Turing.MultiTape.Plumbing.TapeContents
 public import Cslib.Computability.Machines.Turing.MultiTape.TapeLemmas

--- a/Cslib/Computability/Machines/Turing/MultiTape/NormalForms/README.md
+++ b/Cslib/Computability/Machines/Turing/MultiTape/NormalForms/README.md
@@ -1,0 +1,9 @@
+# Machine normal forms
+
+`RewindInput` transforms any machine into one whose halting runs have the native input head at
+position one. It sequences the original machine with the shared rewind controller from
+[Plumbing](../Plumbing). Output, work-tape contents, and work-tape head positions are retained.
+The transformation adds at most the input length plus two steps, including on empty input.
+
+The `HaltsWithInputAtStart` predicate states the property at every halting time, so padded runs
+also satisfy it. The construction does not require the original machine to be total.

--- a/Cslib/Computability/Machines/Turing/MultiTape/NormalForms/RewindInput.lean
+++ b/Cslib/Computability/Machines/Turing/MultiTape/NormalForms/RewindInput.lean
@@ -1,0 +1,83 @@
+/-
+Copyright (c) 2026 Samuel Schlesinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Samuel Schlesinger
+-/
+
+module
+
+public import Cslib.Computability.Machines.Turing.MultiTape.Plumbing.Rewind
+public import Cslib.Computability.Machines.Turing.MultiTape.Plumbing.Sequential
+
+/-!
+# Halting with the input head rewound
+
+`rewindInput` follows an arbitrary machine with the native-input rewind controller. It preserves
+all work tapes, work-tape head positions, and output, and halts with the input head at position one.
+The overhead is at most the input length plus two, including for empty input.
+-/
+
+@[expose] public section
+
+namespace Turing.MultiTapeTM
+
+variable {k : ℕ} {Symbol State : Type*} {input : List Symbol}
+
+/-- Normalize a machine to halt with its input head at the initial position. -/
+def rewindInput (tm : MultiTapeTM k Symbol State) : MultiTapeTM k Symbol (State ⊕ RewindState) :=
+  tm.seq (rewind .input)
+
+/-- Exact input-rewind execution from any configuration, once the first machine reaches its
+least halting time. Everything other than the input head and control state is preserved. -/
+lemma runFrom_rewindInput (tm : MultiTapeTM k Symbol State) (cfg : Cfg k Symbol State input)
+    (u : ℕ) (hhalt : (tm.runFrom cfg u).state = none)
+    (hactive : ∀ m < u, (tm.runFrom cfg m).state ≠ none) :
+    tm.rewindInput.runFrom (Sequential.left (rewind .input) cfg)
+        (u + ((tm.runFrom cfg u).inputPos.val - 1 + 2)) =
+      Sequential.right (Rewind.inputCfg (tm.runFrom cfg u) none 1) := by
+  rw [rewindInput, runFrom_seq tm (rewind .input) cfg u _ hhalt hactive]
+  exact congrArg Sequential.right (Rewind.runFrom_input (tm.runFrom cfg u))
+
+/-- Any halting computation can be normalized to finish with its input head reset.
+The bound accepts padded native halting times. -/
+lemma rewindInput_halts (tm : MultiTapeTM k Symbol State) (t : ℕ)
+    (hhalt : (tm.runFrom (tm.initCfg input) t).state = none) :
+    ∃ t' ≤ t + input.length + 2,
+      tm.rewindInput.runFrom (tm.rewindInput.initCfg input) t' =
+        Sequential.right (Rewind.inputCfg (tm.runFrom (tm.initCfg input) t) none 1) := by
+  obtain ⟨u, hu, hhaltu, hactiveu⟩ := exists_minimal_halting_time tm (tm.initCfg input) t hhalt
+  refine ⟨u + ((tm.runFrom (tm.initCfg input) u).inputPos.val - 1 + 2), ?_, ?_⟩
+  · have := (tm.runFrom (tm.initCfg input) u).inputPos.isLt
+    omega
+  · rw [tm.runFrom_eq_of_halt (tm.initCfg input) hu hhaltu]
+    exact runFrom_rewindInput tm (tm.initCfg input) u hhaltu hactiveu
+
+/-- Every halting run from an initial configuration has its input head at the initial position. -/
+def HaltsWithInputAtStart (tm : MultiTapeTM k Symbol State) : Prop :=
+  ∀ (input : List Symbol) (t : ℕ), (tm.runFrom (tm.initCfg input) t).state = none →
+    (tm.runFrom (tm.initCfg input) t).inputPos = 1
+
+/-- The transformed machine satisfies the normal form at every halting time, including padding. -/
+lemma rewindInput_haltsWithInputAtStart (tm : MultiTapeTM k Symbol State) :
+    HaltsWithInputAtStart tm.rewindInput := by
+  intro input t ht
+  have hnative : (tm.runFrom (tm.initCfg input) t).state = none := by
+    by_contra hn
+    have hactive (m : ℕ) (hm : m < t) : (tm.runFrom (tm.initCfg input) m).state ≠ none :=
+      fun h => hn (tm.runFrom_state_eq_none_mono (tm.initCfg input) (by omega) h)
+    have hleft := Sequential.runFrom_left tm (rewind .input) (tm.initCfg input) t hactive
+    change ((tm.seq (rewind .input)).runFrom
+      (Sequential.left (rewind .input) (tm.initCfg input)) t).state = none at ht
+    rw [hleft] at ht
+    simp [Sequential.left] at ht
+  obtain ⟨s, _, hfinal⟩ := rewindInput_halts tm t hnative
+  have hs : (tm.rewindInput.runFrom (tm.rewindInput.initCfg input) s).state = none := by
+    rw [hfinal]
+    rfl
+  rcases Nat.le_total t s with hle | hle
+  · have heq := tm.rewindInput.runFrom_eq_of_halt (tm.rewindInput.initCfg input) hle ht
+    exact congrArg Cfg.inputPos (heq.symm.trans hfinal)
+  · rw [tm.rewindInput.runFrom_eq_of_halt (tm.rewindInput.initCfg input) hle hs, hfinal]
+    rfl
+
+end Turing.MultiTapeTM

--- a/Cslib/Computability/Machines/Turing/MultiTape/Plumbing/README.md
+++ b/Cslib/Computability/Machines/Turing/MultiTape/Plumbing/README.md
@@ -9,3 +9,5 @@ These modules describe executable machines and their effects on configurations a
   contributes one visited cell to space. Arbitrary data on unused tapes is preserved.
 - `OutputToWorkTape` redirects output to one fresh tape, including the symbol on a halting step.
 - `InputFromWorkTape` simulates the native input on a work tape, preserving boundary clamping.
+- `Rewind` shares one controller between native-input and work-tape rewinding. Work-tape rewind
+  starts immediately after contiguous contents and finishes at their first cell, including when empty.

--- a/Cslib/Computability/Machines/Turing/MultiTape/Plumbing/Rewind.lean
+++ b/Cslib/Computability/Machines/Turing/MultiTape/Plumbing/Rewind.lean
@@ -1,0 +1,177 @@
+/-
+Copyright (c) 2026 Samuel Schlesinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Samuel Schlesinger
+-/
+
+module
+
+public import Cslib.Computability.Machines.Turing.MultiTape.Plumbing.TapeContents
+public import Cslib.Computability.Machines.Turing.MultiTape.Plumbing.Basic
+
+/-!
+# Rewinding a tape
+
+One controller rewinds either the native input head or a selected work-tape head. It first moves
+left, scans left through nonblank cells, then moves right and halts. The initial left move handles
+a head starting on the right blank boundary, including when the contents are empty.
+-/
+
+@[expose] public section
+
+namespace Turing.MultiTapeTM
+
+variable {k : ℕ} {Symbol State : Type*} {input : List Symbol}
+
+/-- The head operated by a rewind machine. -/
+inductive RewindHead (k : ℕ)
+  | input
+  | work (i : Fin k)
+
+/-- Enter the contents before scanning for the left blank boundary. -/
+inductive RewindState
+  | start
+  | scan
+
+instance : Finite RewindState :=
+  Finite.of_injective (fun | .start => true | .scan => false)
+    (by intro a b h; cases a <;> cases b <;> simp_all)
+
+/-- Rewind the selected head, retaining all tape contents and accumulated output. -/
+def rewind (head : RewindHead k) : MultiTapeTM k Symbol RewindState where
+  q₀ := .start
+  tr q input work :=
+    let cell := match head with | .input => input | .work i => work i
+    let done := match q with | .start => false | .scan => !cell.isSome
+    let move : SignType := if done then 1 else -1
+    ⟨(match head with | .input => move | .work _ => 0),
+      (fun i => (none, match head with
+        | .input => 0
+        | .work j => if i = j then move else 0)),
+      none, if done then none else some .scan⟩
+
+namespace Rewind
+
+/-- A rewind configuration at a specified work-tape position. -/
+def workCfg (cfg : Cfg k Symbol State input) (i : Fin k)
+    (q : Option RewindState) (p : ℤ) : Cfg k Symbol RewindState input :=
+  { cfg.withState q with workTapePos := Function.update cfg.workTapePos i p }
+
+/-- A rewind configuration at a specified native input position. -/
+def inputCfg (cfg : Cfg k Symbol State input)
+    (q : Option RewindState) (p : Fin (input.length + 2)) : Cfg k Symbol RewindState input :=
+  { cfg.withState q with inputPos := p }
+
+/-- The initial work-tape move enters the contents from their right boundary. -/
+lemma step_work_start (cfg : Cfg k Symbol State input) (i : Fin k) (p : ℤ) :
+    (rewind (.work i)).step (workCfg cfg i (some .start) p) =
+      workCfg cfg i (some .scan) (p - 1) := by
+  ext j z <;> simp [step, rewind, workCfg, Cfg.withState, Function.update_apply, sub_eq_add_neg]
+  split_ifs <;> simp_all
+
+/-- Scanning a nonblank work-tape cell moves one position left. -/
+lemma step_work_scan (cfg : Cfg k Symbol State input) (i : Fin k) (p : ℤ)
+    (h : (cfg.workTapes i p).isSome) :
+    (rewind (.work i)).step (workCfg cfg i (some .scan) p) =
+      workCfg cfg i (some .scan) (p - 1) := by
+  have hn := Option.isSome_iff_ne_none.mp h
+  ext j z <;>
+    simp [step, rewind, workCfg, Cfg.withState, Cfg.workTapeSymbols, hn,
+      Function.update_apply, sub_eq_add_neg]
+  split_ifs <;> simp_all
+
+/-- Scanning blank finishes with the head one position to its right. -/
+lemma step_work_stop (cfg : Cfg k Symbol State input) (i : Fin k) (p : ℤ)
+    (h : cfg.workTapes i p = none) :
+    (rewind (.work i)).step (workCfg cfg i (some .scan) p) = workCfg cfg i none (p + 1) := by
+  ext j z <;>
+    simp [step, rewind, workCfg, Cfg.withState, Cfg.workTapeSymbols, h, Function.update_apply]
+  split_ifs <;> simp_all
+
+/-- Every prefix of a work-tape rewind traverses exactly the occupied suffix. -/
+lemma runFrom_work_scan (cfg : Cfg k Symbol State input) (i : Fin k) (xs : List Symbol)
+    (htape : cfg.workTapes i = listTape xs) (r : ℕ) (hr : r ≤ xs.length) :
+    (rewind (.work i)).runFrom (workCfg cfg i (some .scan) (xs.length - 1)) r =
+      workCfg cfg i (some .scan) (xs.length - 1 - r) := by
+  have hstep (s : ℕ) (hs : s < r) := step_work_scan cfg i (xs.length - 1 - s)
+    (by rw [htape]; exact listTape_isSome xs (by omega) (by omega))
+  convert runFrom_eq_of_step (rewind (.work i))
+    (fun s => workCfg cfg i (some .scan) (xs.length - 1 - s)) r (fun s hs => ?_) using 1
+  · simp
+  · convert hstep s hs using 1
+    congr 1
+    omega
+
+/-- Rewind contiguous work-tape contents from the blank cell immediately after them.
+This takes `xs.length + 2` steps and preserves the other heads, all contents, and output. -/
+lemma runFrom_work (cfg : Cfg k Symbol State input) (i : Fin k) (xs : List Symbol)
+    (htape : cfg.workTapes i = listTape xs) :
+    (rewind (.work i)).runFrom (workCfg cfg i (some .start) xs.length) (xs.length + 2) =
+      workCfg cfg i none 0 := by
+  rw [runFrom_succ_eq_step, step_work_start, runFrom_succ_eq_step',
+    runFrom_work_scan cfg i xs htape xs.length le_rfl]
+  rw [show (xs.length : ℤ) - 1 - xs.length = -1 by omega]
+  simpa using step_work_stop cfg i (-1) (by rw [htape]; rfl)
+
+/-- The work-tape rewind does not halt before its final move back to the first cell. -/
+lemma work_active (cfg : Cfg k Symbol State input) (i : Fin k) (xs : List Symbol)
+    (htape : cfg.workTapes i = listTape xs) (r : ℕ) (hr : r < xs.length + 2) :
+    ((rewind (.work i)).runFrom (workCfg cfg i (some .start) xs.length) r).state ≠ none := by
+  cases r with
+  | zero => simp [workCfg]
+  | succ r =>
+    rw [runFrom_succ_eq_step, step_work_start, runFrom_work_scan cfg i xs htape r (by omega)]
+    simp [workCfg]
+
+/-- The first native-input rewind step moves left, with the native boundary clamp. -/
+lemma step_input_start (cfg : Cfg k Symbol State input) (p : Fin (input.length + 2)) :
+    (rewind .input).step (inputCfg cfg (some .start) p) =
+      inputCfg cfg (some .scan) (moveInputPos p (-1)) := by
+  ext i z <;> simp [step, rewind, inputCfg, Cfg.withState]
+
+/-- A nonboundary native-input position takes one step to the left. -/
+lemma step_input_scan (cfg : Cfg k Symbol State input) (p : Fin (input.length + 2))
+    (hp : 0 < p.val) (hlt : p.val ≤ input.length) :
+    (rewind .input).step (inputCfg cfg (some .scan) p) =
+      inputCfg cfg (some .scan) (moveInputPos p (-1)) := by
+  have hleft : p ≠ 0 := by intro h; subst p; simp at hp
+  have hright : p.val ≠ input.length + 1 := by omega
+  ext i z <;>
+    simp [step, rewind, inputCfg, Cfg.withState, Cfg.inputSymbol, hleft, hright]
+
+/-- At the left blank boundary, move to the initial input position and halt. -/
+lemma step_input_stop (cfg : Cfg k Symbol State input) :
+    (rewind .input).step (inputCfg cfg (some .scan) 0) = inputCfg cfg none 1 := by
+  ext i z <;> simp [step, rewind, inputCfg, Cfg.withState, Cfg.inputSymbol, moveInputPos]
+
+/-- A native input scan reaches its left blank boundary. -/
+lemma runFrom_input_scan (cfg : Cfg k Symbol State input) (n : ℕ) (hn : n ≤ input.length) :
+    (rewind .input).runFrom (inputCfg cfg (some .scan) ⟨n, by omega⟩) n =
+      inputCfg cfg (some .scan) 0 := by
+  induction n with
+  | zero => rfl
+  | succ n ih =>
+    rw [runFrom_succ_eq_step, step_input_scan cfg _ (by simp) hn]
+    have hm : moveInputPos (⟨n + 1, by omega⟩ : Fin (input.length + 2)) (-1) =
+        ⟨n, by omega⟩ := by
+      apply Fin.ext
+      simp [moveInputPos, show n < input.length + 2 by omega]
+    rw [hm]
+    exact ih (by omega)
+
+/-- Rewind the native input from any legal head position. Both blank boundaries and empty input
+are allowed. Only the input head and control state change. -/
+lemma runFrom_input (cfg : Cfg k Symbol State input) :
+    (rewind .input).runFrom (inputCfg cfg (some .start) cfg.inputPos)
+        (cfg.inputPos.val - 1 + 2) = inputCfg cfg none 1 := by
+  rw [runFrom_succ_eq_step, step_input_start, runFrom_succ_eq_step']
+  have hm : moveInputPos cfg.inputPos (-1) =
+      (⟨cfg.inputPos.val - 1, by have := cfg.inputPos.isLt; omega⟩ : Fin (input.length + 2)) := by
+    apply Fin.ext
+    simp [moveInputPos]
+    split_ifs <;> simp_all <;> omega
+  rw [hm, runFrom_input_scan cfg _ (by have := cfg.inputPos.isLt; omega), step_input_stop]
+
+end Rewind
+
+end Turing.MultiTapeTM

--- a/CslibTests.lean
+++ b/CslibTests.lean
@@ -21,5 +21,6 @@ import CslibTests.Modal.Stlc
 import CslibTests.MultiTapeAdapters
 import CslibTests.MultiTapeComplexity
 import CslibTests.MultiTapePlumbing
+import CslibTests.MultiTapeRewind
 import CslibTests.Reduction
 import CslibTests.StatefulProcesses

--- a/CslibTests/MultiTapeRewind.lean
+++ b/CslibTests/MultiTapeRewind.lean
@@ -1,0 +1,44 @@
+/-
+Copyright (c) 2026 Samuel Schlesinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Samuel Schlesinger
+-/
+
+import Cslib.Computability.Machines.Turing.MultiTape.NormalForms.RewindInput
+
+namespace CslibTests.MultiTapeRewind
+
+open Turing.MultiTapeTM
+
+private def finish (move : SignType) (symbol : Bool) : Turing.MultiTapeTM 0 Bool Unit where
+  q₀ := ()
+  tr _ _ _ := ⟨move, Fin.elim0, some symbol, none⟩
+
+-- Rewinding works when the native halt is at either boundary, including on empty input.
+example : ((finish (-1) true).rewindInput.runFrom
+    ((finish (-1) true).rewindInput.initCfg [false]) 3).inputPos = 1 := by rfl
+
+example : ((finish 1 true).rewindInput.runFrom
+    ((finish 1 true).rewindInput.initCfg [false]) 4).inputPos = 1 := by rfl
+
+example : ((finish 1 true).rewindInput.runFrom
+    ((finish 1 true).rewindInput.initCfg []) 3).state = none := by rfl
+
+example : ((finish 1 true).rewindInput.runFrom
+    ((finish 1 true).rewindInput.initCfg []) 3).output = [true] := by rfl
+
+private def filled (xs : List Bool) : Cfg 1 Bool Unit [] :=
+  ⟨none, 1, fun _ => listTape xs, fun _ => xs.length, []⟩
+
+-- Work-tape rewind preserves the contents and resets the head, even for empty contents.
+example : ((rewind (.work (0 : Fin 1))).runFrom
+    (Rewind.workCfg (filled []) 0 (some .start) 0) 2).workTapePos 0 = 0 := by rfl
+
+example : ((rewind (.work (0 : Fin 1))).runFrom
+    (Rewind.workCfg (filled [true, false]) 0 (some .start) 2) 4).state = none := by rfl
+
+example : ((rewind (.work (0 : Fin 1))).runFrom
+    (Rewind.workCfg (filled [true, false]) 0 (some .start) 2) 4).workTapes 0 =
+      listTape [true, false] := by rfl
+
+end CslibTests.MultiTapeRewind


### PR DESCRIPTION
Add a shared controller for rewinding native input and contiguous work-tape contents. Use it to transform any machine into one that halts with its input head at the initial position, preserving output and work tapes.

Part 4/6 of the TM composition stack. Depends on #872. Next: #874.

Validation: strict build, import checks, full tests, and linters.

This PR was composed with Astra via Codex.
