### PR TITLE
feat(MultiTapeTM): compose machines using tape transformations

### DIFF
--- a/Cslib.lean
+++ b/Cslib.lean
@@ -49,6 +49,11 @@ public import Cslib.Computability.Languages.SafetyLiveness
 public import Cslib.Computability.Machines.Turing.MultiTape.Deterministic
 public import Cslib.Computability.Machines.Turing.MultiTape.NormalForms.RewindInput
 public import Cslib.Computability.Machines.Turing.MultiTape.Plumbing.Basic
+public import Cslib.Computability.Machines.Turing.MultiTape.Plumbing.Composition
+public import Cslib.Computability.Machines.Turing.MultiTape.Plumbing.Composition.Defs
+public import Cslib.Computability.Machines.Turing.MultiTape.Plumbing.Composition.Layout
+public import Cslib.Computability.Machines.Turing.MultiTape.Plumbing.Composition.Rewind
+public import Cslib.Computability.Machines.Turing.MultiTape.Plumbing.Composition.Simulation
 public import Cslib.Computability.Machines.Turing.MultiTape.Plumbing.ExtendTapes
 public import Cslib.Computability.Machines.Turing.MultiTape.Plumbing.InputFromWorkTape
 public import Cslib.Computability.Machines.Turing.MultiTape.Plumbing.InputFromWorkTape.Defs

--- a/Cslib/Computability/Machines/Turing/MultiTape/Plumbing/Composition.lean
+++ b/Cslib/Computability/Machines/Turing/MultiTape/Plumbing/Composition.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2026 Samuel Schlesinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Samuel Schlesinger
+-/
+
+module
+
+public import Cslib.Computability.Machines.Turing.MultiTape.Plumbing.Composition.Rewind
+
+/-!
+# Correctness of multi-tape composition
+
+`comp_haltsWithOutput` proves that the composite machine returns the second machine's output
+on the first machine's result. The first phase takes one step per native step; the second takes
+two, following a rewind of the intermediate output and one initial classification step.
+-/
+
+@[expose] public section
+
+namespace Turing.MultiTapeTM
+
+open Composition
+
+variable {k₀ k₁ : ℕ}
+variable {Symbol State₀ State₁ : Type*}
+
+variable (tm₀ : MultiTapeTM k₀ Symbol State₀) (tm₁ : MultiTapeTM k₁ Symbol State₁)
+
+/-- Composition returns the second machine's output on the first machine's result.
+The first halting time must be minimal; the second may be padded. -/
+theorem comp_haltsWithOutput
+    {input out₀ out₁ : List Symbol} {u v : ℕ}
+    (hhalt₀ : (tm₀.runFrom (tm₀.initCfg input) u).state = none)
+    (hactive₀ : ∀ m < u, (tm₀.runFrom (tm₀.initCfg input) m).state ≠ none)
+    (hout₀ : (tm₀.runFrom (tm₀.initCfg input) u).output = out₀)
+    (hhalt₁ : (tm₁.runFrom (tm₁.initCfg out₀) v).state = none)
+    (hout₁ : (tm₁.runFrom (tm₁.initCfg out₀) v).output = out₁) :
+    ((comp tm₀ tm₁).runFrom ((comp tm₀ tm₁).initCfg input)
+        (u + (out₀.length + 3) + 2 * v)).state = none ∧
+      ((comp tm₀ tm₁).runFrom ((comp tm₀ tm₁).initCfg input)
+          (u + (out₀.length + 3) + 2 * v)).output = out₁ := by
+  subst out₀
+  subst out₁
+  have hfinal := runFrom_secondPhase tm₀ tm₁
+    (tm₀.runFrom (tm₀.initCfg input) u)
+    (tm₁.initCfg (tm₀.runFrom (tm₀.initCfg input) u).output) v
+  rw [← runFrom_to_secondInit tm₀ tm₁ input u hhalt₀ hactive₀, ← runFrom_add] at hfinal
+  rw [hfinal]
+  simp only [embedSecond, hhalt₁, and_self]
+
+end Turing.MultiTapeTM

--- a/Cslib/Computability/Machines/Turing/MultiTape/Plumbing/Composition/Defs.lean
+++ b/Cslib/Computability/Machines/Turing/MultiTape/Plumbing/Composition/Defs.lean
@@ -1,0 +1,175 @@
+/-
+Copyright (c) 2026 Samuel Schlesinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Samuel Schlesinger
+-/
+
+module
+
+public import Cslib.Computability.Machines.Turing.MultiTape.Plumbing.ExtendTapes
+public import Cslib.Computability.Machines.Turing.MultiTape.Plumbing.OutputToWorkTape
+public import Cslib.Computability.Machines.Turing.MultiTape.Plumbing.InputFromWorkTape
+public import Cslib.Computability.Machines.Turing.MultiTape.Plumbing.Rewind
+public import Cslib.Computability.Machines.Turing.MultiTape.Plumbing.Sequential
+
+/-!
+# Composition of deterministic multi-tape Turing machines
+
+The composite redirects the first machine's output to an intermediate work tape, rewinds it,
+and simulates the second machine with that tape as its input. Work tapes occupy disjoint blocks.
+A classification step after each simulated input move restores the native boundary behavior.
+Both machines use the same alphabet; no extra tape symbols are required.
+
+`comp` is the executable construction. The `Composition` namespace also contains the
+configuration embeddings used by the simulation proofs.
+-/
+
+@[expose] public section
+
+namespace Turing.MultiTapeTM
+
+variable {k₀ k₁ : ℕ}
+variable {Symbol State₀ State₁ : Type*}
+
+/-- Number of work tapes used by the composition of a `k₀`- and a `k₁`-tape machine. -/
+abbrev compositionTapeCount (k₀ k₁ : ℕ) := k₀ + 1 + k₁
+
+/-- Physical coordinate of work tape `i` of the first machine. -/
+def compositionFirstTapeIdx (k₁ : ℕ) (i : Fin k₀) : Fin (compositionTapeCount k₀ k₁) :=
+  i.castSucc.castAdd k₁
+
+/-- Physical coordinate of the tape containing the intermediate output. -/
+def compositionIntermediateTapeIdx (k₀ k₁ : ℕ) : Fin (compositionTapeCount k₀ k₁) :=
+  (Fin.last k₀).castAdd k₁
+
+/-- Physical coordinate of work tape `i` of the second machine. -/
+def compositionSecondTapeIdx (k₀ k₁ : ℕ) (i : Fin k₁) :
+    Fin (compositionTapeCount k₀ k₁) :=
+  Fin.natAdd (k₀ + 1) i
+
+@[simp]
+lemma compositionFirstTapeIdx_val (k₁ : ℕ) (i : Fin k₀) :
+    (compositionFirstTapeIdx k₁ i).val = i.val := rfl
+
+@[simp]
+lemma compositionIntermediateTapeIdx_val (k₀ k₁ : ℕ) :
+    (compositionIntermediateTapeIdx k₀ k₁).val = k₀ := rfl
+
+@[simp]
+lemma compositionSecondTapeIdx_val (k₀ : ℕ) (i : Fin k₁) :
+    (compositionSecondTapeIdx k₀ k₁ i).val = k₀ + 1 + i.val := rfl
+
+/-- States of the three sequential phases: output, rewind, and virtual-input execution. -/
+abbrev CompositionState (State₀ State₁ : Type*) := State₀ ⊕ (RewindState ⊕ InputState State₁)
+
+/-- Assemble the first work-tape block, the intermediate tape, and the second block.
+The same layout is used for tape contents and head positions. -/
+@[simp]
+def Composition.tapes {α : Type*} (first : Fin k₀ → α) (middle : α) (second : Fin k₁ → α)
+    (i : Fin (compositionTapeCount k₀ k₁)) : α :=
+  if h : i.val < k₀ then first ⟨i, h⟩
+  else if hmiddle : i.val = k₀ then middle
+  else second ⟨i.val - (k₀ + 1), by have := i.isLt; simp only [compositionTapeCount] at *; omega⟩
+
+namespace Composition
+
+/-- Place the first machine and its output tape before the second work-tape block. -/
+def outputEmbedding (k₀ k₁ : ℕ) : Fin (k₀ + 1) ↪ Fin (compositionTapeCount k₀ k₁) :=
+  ⟨Fin.castAdd k₁, Fin.castAdd_injective (k₀ + 1) k₁⟩
+
+/-- Place the virtual input before the second machine's work tapes. -/
+def inputEmbedding (k₀ k₁ : ℕ) : Fin (k₁ + 1) ↪ Fin (compositionTapeCount k₀ k₁) :=
+  ⟨fun i => ⟨k₀ + i.val, by have := i.isLt; simp only [compositionTapeCount]; omega⟩,
+    fun i j h => Fin.ext (by have := congrArg Fin.val h; dsimp at this; omega)⟩
+
+@[simp]
+lemma inputEmbedding_val (i : Fin (k₁ + 1)) :
+    (inputEmbedding k₀ k₁ i).val = k₀ + i.val := rfl
+
+/-- The first machine, with output redirected and the second tape block left idle. -/
+def outputMachine (tm₀ : MultiTapeTM k₀ Symbol State₀) (k₁ : ℕ) :=
+  tm₀.outputToWorkTape.extendTapes (outputEmbedding k₀ k₁)
+
+/-- The second machine, with virtual input and the first tape block left idle. -/
+def inputMachine (k₀ : ℕ) (tm₁ : MultiTapeTM k₁ Symbol State₁) :=
+  tm₁.inputFromWorkTape.extendTapes (inputEmbedding k₀ k₁)
+
+end Composition
+
+/-- Compose functions by redirecting output, rewinding it, then using it as the next input. -/
+def comp (tm₀ : MultiTapeTM k₀ Symbol State₀) (tm₁ : MultiTapeTM k₁ Symbol State₁) :
+    MultiTapeTM (compositionTapeCount k₀ k₁) Symbol (CompositionState State₀ State₁) :=
+  (Composition.outputMachine tm₀ k₁).seq
+    ((rewind (.work (compositionIntermediateTapeIdx k₀ k₁))).seq
+      (Composition.inputMachine k₀ tm₁))
+
+namespace Composition
+
+/-- Embed a first-machine configuration into the first phase of the composite machine. -/
+def embedFirst
+    (_tm₀ : MultiTapeTM k₀ Symbol State₀)
+    (_tm₁ : MultiTapeTM k₁ Symbol State₁)
+    {input : List Symbol}
+    (cfg : Cfg k₀ Symbol State₀ input) :
+    Cfg (compositionTapeCount k₀ k₁) Symbol (CompositionState State₀ State₁) input where
+  state := match cfg.state with
+    | some q => some (.inl q)
+    | none => some (.inr (.inl .start))
+  inputPos := cfg.inputPos
+  workTapes := tapes cfg.workTapes (listTape cfg.output) (fun _ _ => none)
+  workTapePos := tapes cfg.workTapePos cfg.output.length (fun _ => 0)
+  output := []
+
+/-- Embed a second-machine configuration into the second phase of the composite machine. -/
+def embedSecond
+    (_tm₀ : MultiTapeTM k₀ Symbol State₀)
+    (_tm₁ : MultiTapeTM k₁ Symbol State₁)
+    {firstInput : List Symbol}
+    (firstCfg : Cfg k₀ Symbol State₀ firstInput)
+    {secondInput : List Symbol}
+    (secondCfg : Cfg k₁ Symbol State₁ secondInput) :
+    Cfg (compositionTapeCount k₀ k₁) Symbol
+      (CompositionState State₀ State₁) firstInput where
+  state := match secondCfg.state with
+    | some q => some (.inr (.inr (.run q (InputFromWorkTape.inputMode secondCfg.inputPos))))
+    | none => none
+  inputPos := firstCfg.inputPos
+  workTapes := tapes firstCfg.workTapes (listTape secondInput) secondCfg.workTapes
+  workTapePos := tapes firstCfg.workTapePos
+    (InputFromWorkTape.virtualInputPos secondCfg.inputPos) secondCfg.workTapePos
+  output := secondCfg.output
+
+/-- The intermediate configuration between the moving and classifying halves of a simulated
+second-machine step. -/
+def classifyCfg
+    (_tm₀ : MultiTapeTM k₀ Symbol State₀)
+    (_tm₁ : MultiTapeTM k₁ Symbol State₁)
+    {firstInput : List Symbol}
+    (firstCfg : Cfg k₀ Symbol State₀ firstInput)
+    {secondInput : List Symbol}
+    (secondCfg : Cfg k₁ Symbol State₁ secondInput)
+    (boundary : InputBoundary) :
+    Cfg (compositionTapeCount k₀ k₁) Symbol
+      (CompositionState State₀ State₁) firstInput :=
+  { embedSecond _tm₀ _tm₁ firstCfg secondCfg with
+    state := secondCfg.state.map fun q => (.inr (.inr (.classify q boundary))) }
+
+/-- A first-phase boundary configuration with a chosen control state and intermediate head
+position. -/
+def intermediateCfg
+    (_tm₀ : MultiTapeTM k₀ Symbol State₀)
+    (_tm₁ : MultiTapeTM k₁ Symbol State₁)
+    {input : List Symbol}
+    (cfg : Cfg k₀ Symbol State₀ input)
+    (state : CompositionState State₀ State₁)
+    (pos : ℤ) :
+    Cfg (compositionTapeCount k₀ k₁) Symbol (CompositionState State₀ State₁) input :=
+  { embedFirst _tm₀ _tm₁ cfg with
+    state := some state
+    workTapePos := fun i =>
+      if i.val = k₀ then pos
+      else (embedFirst _tm₀ _tm₁ cfg).workTapePos i }
+
+end Composition
+
+end Turing.MultiTapeTM

--- a/Cslib/Computability/Machines/Turing/MultiTape/Plumbing/Composition/Layout.lean
+++ b/Cslib/Computability/Machines/Turing/MultiTape/Plumbing/Composition/Layout.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2026 Samuel Schlesinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Samuel Schlesinger
+-/
+
+module
+
+public import Cslib.Computability.Machines.Turing.MultiTape.Plumbing.Composition.Defs
+
+/-! # Relating the composition tape layout to injected work tapes -/
+
+@[expose] public section
+
+namespace Turing.MultiTapeTM.Composition
+
+variable {k₀ k₁ : ℕ} {α : Type*}
+
+/-- Extending the output machine yields the first block and the middle tape. -/
+lemma extend_output (first : Fin k₀ → α) (middle : α) (second : Fin k₁ → α)
+    (dummyFirst : Fin k₀ → α) (dummyMiddle : α) :
+    ExtendTapes.extend (outputEmbedding k₀ k₁) (Fin.lastCases middle first)
+      (tapes dummyFirst dummyMiddle second) = tapes first middle second := by
+  funext i
+  refine Fin.addCases (fun j => ?_) (fun j => ?_) i
+  · change ExtendTapes.extend (outputEmbedding k₀ k₁) _ _ (outputEmbedding k₀ k₁ j) = _
+    rw [ExtendTapes.extend_apply]
+    refine Fin.lastCases ?_ (fun j => ?_) j
+    · simp [tapes]
+    · simp [tapes]
+  · have hj : Fin.natAdd (k₀ + 1) j ∉ Set.range (outputEmbedding k₀ k₁) := by
+      rintro ⟨a, ha⟩
+      have := congrArg Fin.val ha
+      simp only [outputEmbedding, Function.Embedding.coeFn_mk,
+        Fin.val_castAdd, Fin.val_natAdd] at this
+      omega
+    simp [ExtendTapes.extend, hj, tapes, show ¬k₀ + 1 + j.val < k₀ by omega,
+      show k₀ + 1 + j.val ≠ k₀ by omega]
+
+/-- Extending the input machine preserves the first block and fills the remaining tapes. -/
+lemma extend_input (first : Fin k₀ → α) (middle : α) (second : Fin k₁ → α)
+    (dummyMiddle : α) (dummySecond : Fin k₁ → α) :
+    ExtendTapes.extend (inputEmbedding k₀ k₁) (Fin.cases middle second)
+      (tapes first dummyMiddle dummySecond) = tapes first middle second := by
+  funext i
+  by_cases hi : i.val < k₀
+  · have hn : i ∉ Set.range (inputEmbedding k₀ k₁) := by
+      rintro ⟨a, ha⟩
+      have := congrArg Fin.val ha
+      change k₀ + a.val = i.val at this
+      omega
+    simp [ExtendTapes.extend, hn, tapes, hi]
+  · let j : Fin (k₁ + 1) := ⟨i.val - k₀, by
+      have := i.isLt
+      dsimp [compositionTapeCount] at *
+      omega⟩
+    have hj : inputEmbedding k₀ k₁ j = i :=
+      Fin.ext (by change k₀ + (i.val - k₀) = i.val; omega)
+    rw [← hj, ExtendTapes.extend_apply]
+    generalize j = a
+    refine Fin.cases ?_ (fun a => ?_) a
+    · simp [tapes]
+    · simp only [Fin.cases_succ, tapes, inputEmbedding_val, Fin.val_succ,
+        add_lt_iff_neg_left, not_lt_zero, ↓reduceDIte, Nat.add_eq_left,
+        Nat.add_eq_zero_iff, one_ne_zero, and_false]
+      congr 1
+      apply Fin.ext
+      simp
+      omega
+
+/-- A constant frame supplies the unused second tape block. -/
+lemma extend_output_const (first : Fin k₀ → α) (middle d : α) :
+    ExtendTapes.extend (outputEmbedding k₀ k₁) (Fin.lastCases middle first) (fun _ => d) =
+      tapes first middle (fun _ => d) := by
+  have hconst : tapes (fun _ : Fin k₀ => d) d (fun _ : Fin k₁ => d) = (fun _ => d) := by
+    funext i
+    simp [tapes]
+  rw [← hconst]
+  exact extend_output first middle (fun _ => d) (fun _ => d) d
+
+end Turing.MultiTapeTM.Composition

--- a/Cslib/Computability/Machines/Turing/MultiTape/Plumbing/Composition/Rewind.lean
+++ b/Cslib/Computability/Machines/Turing/MultiTape/Plumbing/Composition/Rewind.lean
@@ -1,0 +1,152 @@
+/-
+Copyright (c) 2026 Samuel Schlesinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Samuel Schlesinger
+-/
+
+module
+
+public import Cslib.Computability.Machines.Turing.MultiTape.Plumbing.Composition.Simulation
+
+/-! # Assembling output redirection, rewind, and input substitution -/
+
+@[expose] public section
+
+namespace Turing.MultiTapeTM.Composition
+
+variable {k₀ k₁ : ℕ} {Symbol State₀ State₁ : Type*} {input : List Symbol}
+variable (tm₀ : MultiTapeTM k₀ Symbol State₀) (tm₁ : MultiTapeTM k₁ Symbol State₁)
+
+/-- Extend the output machine with the blank second-machine tape block. -/
+def outputLift (cfg : Cfg (k₀ + 1) Symbol State₀ input) :=
+  ExtendTapes.embed (outputEmbedding k₀ k₁) cfg (fun _ _ => none) (fun _ => 0)
+
+@[simp]
+lemma outputLift_embed (cfg : Cfg k₀ Symbol State₀ input) :
+    outputLift (k₁ := k₁) (OutputToWorkTape.embed cfg) =
+      ⟨cfg.state, cfg.inputPos, tapes cfg.workTapes (listTape cfg.output) (fun _ _ => none),
+        tapes cfg.workTapePos cfg.output.length (fun _ => 0), []⟩ := by
+  apply Cfg.ext <;> try rfl
+  · exact extend_output_const _ _ _
+  · exact extend_output_const _ _ _
+
+/-- The first phase is an output-redirection run followed by the generic sequential handoff. -/
+lemma embedFirst_eq (cfg : Cfg k₀ Symbol State₀ input) :
+    embedFirst tm₀ tm₁ cfg =
+      Sequential.left ((rewind (.work (compositionIntermediateTapeIdx k₀ k₁))).seq
+        (inputMachine k₀ tm₁)) (outputLift (OutputToWorkTape.embed cfg)) := by
+  rw [outputLift_embed]
+  cases hs : cfg.state <;> simp [embedFirst, hs, Sequential.left, seq, rewind, Cfg.withState]
+
+/-- Tape extension and output redirection commute with every native run. -/
+lemma runFrom_outputLift (cfg : Cfg k₀ Symbol State₀ input) (n : ℕ) :
+    (outputMachine tm₀ k₁).runFrom (outputLift (OutputToWorkTape.embed cfg)) n =
+      outputLift (OutputToWorkTape.embed (tm₀.runFrom cfg n)) := by
+  simp only [outputMachine, outputLift, ExtendTapes.runFrom_embed, OutputToWorkTape.runFrom_embed]
+
+/-- The first embedding takes initial configurations to initial configurations. -/
+lemma embedFirst_initCfg (input : List Symbol) :
+    embedFirst tm₀ tm₁ (tm₀.initCfg input) = (comp tm₀ tm₁).initCfg input := by
+  apply Cfg.ext <;> try rfl
+  · funext i p
+    cases p <;> simp [embedFirst, ite_apply, listTape]
+  · funext i
+    simp [embedFirst]
+
+/-- The first component runs up to its earliest halt. -/
+lemma runFrom_firstPhase (input : List Symbol) (n : ℕ)
+    (hactive : ∀ m < n, (tm₀.runFrom (tm₀.initCfg input) m).state ≠ none) :
+    (comp tm₀ tm₁).runFrom ((comp tm₀ tm₁).initCfg input) n =
+      embedFirst tm₀ tm₁ (tm₀.runFrom (tm₀.initCfg input) n) := by
+  rw [← embedFirst_initCfg, embedFirst_eq, comp, Sequential.runFrom_left]
+  · rw [runFrom_outputLift, ← embedFirst_eq]
+  · intro m hm
+    rw [runFrom_outputLift]
+    exact hactive m hm
+
+/-- Embed the generic rewind phase into the two nested sequential machines. -/
+def rewindLift (cfg : Cfg k₀ Symbol State₀ input) (q : Option RewindState) (pos : ℤ) :
+    Cfg (compositionTapeCount k₀ k₁) Symbol (CompositionState State₀ State₁) input :=
+  Sequential.right (Sequential.left (inputMachine k₀ tm₁)
+    (Rewind.workCfg (outputLift (OutputToWorkTape.embed cfg))
+      (compositionIntermediateTapeIdx k₀ k₁) q pos))
+
+/-- A scanning rewind configuration has exactly the intermediate-tape layout. -/
+lemma rewindLift_scan (cfg : Cfg k₀ Symbol State₀ input) (pos : ℤ) :
+    rewindLift tm₁ cfg (some .scan) pos =
+      intermediateCfg tm₀ tm₁ cfg (.inr (.inl .scan)) pos := by
+  ext i z <;>
+    simp [rewindLift, Sequential.right, Sequential.left, Rewind.workCfg, Cfg.withState,
+      intermediateCfg, embedFirst, Function.update_apply, Fin.ext_iff]
+
+/-- The final rewind configuration enters the initial virtual-input classifier. -/
+lemma rewindLift_halt (cfg : Cfg k₀ Symbol State₀ input) :
+    rewindLift tm₁ cfg none 0 =
+      intermediateCfg tm₀ tm₁ cfg (.inr (.inr (.classify tm₁.q₀ .right))) 0 := by
+  ext i z <;>
+    simp [rewindLift, Sequential.right, Sequential.left, Rewind.workCfg, Cfg.withState,
+      inputMachine, extendTapes, inputFromWorkTape,
+      intermediateCfg, embedFirst, Function.update_apply, Fin.ext_iff]
+
+/-- The halt of the output machine starts the work-tape rewind at the end of its output. -/
+lemma embedFirst_halt (cfg : Cfg k₀ Symbol State₀ input) (hhalt : cfg.state = none) :
+    embedFirst tm₀ tm₁ cfg = rewindLift tm₁ cfg (some .start) cfg.output.length := by
+  ext i z <;>
+    simp [rewindLift, Sequential.right, Sequential.left, Rewind.workCfg, Cfg.withState,
+      embedFirst, hhalt, Function.update_apply, Fin.ext_iff]
+  split_ifs <;> simp_all
+  omega
+
+/-- After the first machine halts, each scanning step moves left through its output. -/
+lemma runFrom_firstHalt_rewind (cfg : Cfg k₀ Symbol State₀ input) (hhalt : cfg.state = none)
+    (r : ℕ) (hr : r ≤ cfg.output.length) :
+    (comp tm₀ tm₁).runFrom (embedFirst tm₀ tm₁ cfg) (r + 1) =
+      intermediateCfg tm₀ tm₁ cfg (.inr (.inl .scan)) (cfg.output.length - 1 - r) := by
+  rw [embedFirst_halt tm₀ tm₁ cfg hhalt, rewindLift, comp, Sequential.runFrom_right,
+    Sequential.runFrom_left]
+  · rw [runFrom_succ_eq_step, Rewind.step_work_start,
+      Rewind.runFrom_work_scan _ _ cfg.output (by simp) r hr]
+    exact rewindLift_scan tm₀ tm₁ cfg _
+  · intro m hm
+    exact Rewind.work_active _ _ cfg.output (by simp) m (by omega)
+
+/-- Rewinding the output enters the second machine's initial classifier. -/
+lemma runFrom_firstHalt_classify (cfg : Cfg k₀ Symbol State₀ input) (hhalt : cfg.state = none) :
+    (comp tm₀ tm₁).runFrom (embedFirst tm₀ tm₁ cfg) (cfg.output.length + 2) =
+      intermediateCfg tm₀ tm₁ cfg (.inr (.inr (.classify tm₁.q₀ .right))) 0 := by
+  rw [embedFirst_halt tm₀ tm₁ cfg hhalt, rewindLift, comp, Sequential.runFrom_right,
+    Sequential.runFrom_left]
+  · rw [Rewind.runFrom_work _ _ cfg.output (by simp)]
+    exact rewindLift_halt tm₀ tm₁ cfg
+  · intro m hm
+    exact Rewind.work_active _ _ cfg.output (by simp) m hm
+
+/-- The rewound tape is the input-substitution machine's initial classifier configuration. -/
+lemma intermediateCfg_classify_init (cfg : Cfg k₀ Symbol State₀ input) :
+    intermediateCfg tm₀ tm₁ cfg (.inr (.inr (.classify tm₁.q₀ .right))) 0 =
+      classifyCfg tm₀ tm₁ cfg (tm₁.initCfg cfg.output) .right := by
+  ext i p <;>
+    simp [intermediateCfg, embedFirst, classifyCfg, embedSecond, InputFromWorkTape.virtualInputPos]
+  split_ifs <;> simp_all
+  omega
+
+/-- Output rewind and the initial classifier take the output length plus three steps. -/
+lemma runFrom_firstHalt_to_secondInit (cfg : Cfg k₀ Symbol State₀ input)
+    (hhalt : cfg.state = none) :
+    (comp tm₀ tm₁).runFrom (embedFirst tm₀ tm₁ cfg) (cfg.output.length + 3) =
+      embedSecond tm₀ tm₁ cfg (tm₁.initCfg cfg.output) := by
+  rw [runFrom_succ_eq_step', runFrom_firstHalt_classify tm₀ tm₁ cfg hhalt,
+    intermediateCfg_classify_init, step_classify_init]
+
+/-- The first run and output rewind establish the second machine's initial state. -/
+lemma runFrom_to_secondInit (input : List Symbol) (u : ℕ)
+    (hhalt : (tm₀.runFrom (tm₀.initCfg input) u).state = none)
+    (hactive : ∀ m < u, (tm₀.runFrom (tm₀.initCfg input) m).state ≠ none) :
+    (comp tm₀ tm₁).runFrom ((comp tm₀ tm₁).initCfg input)
+        (u + ((tm₀.runFrom (tm₀.initCfg input) u).output.length + 3)) =
+      embedSecond tm₀ tm₁ (tm₀.runFrom (tm₀.initCfg input) u)
+        (tm₁.initCfg (tm₀.runFrom (tm₀.initCfg input) u).output) := by
+  rw [runFrom_add, runFrom_firstPhase tm₀ tm₁ input u hactive,
+    runFrom_firstHalt_to_secondInit tm₀ tm₁ _ hhalt]
+
+end Turing.MultiTapeTM.Composition

--- a/Cslib/Computability/Machines/Turing/MultiTape/Plumbing/Composition/Simulation.lean
+++ b/Cslib/Computability/Machines/Turing/MultiTape/Plumbing/Composition/Simulation.lean
@@ -1,0 +1,86 @@
+/-
+Copyright (c) 2026 Samuel Schlesinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Samuel Schlesinger
+-/
+
+module
+
+public import Cslib.Computability.Machines.Turing.MultiTape.Plumbing.Composition.Layout
+
+/-! # Lifting the generic virtual-input simulation into composition -/
+
+@[expose] public section
+
+namespace Turing.MultiTapeTM.Composition
+
+variable {k₀ k₁ : ℕ} {Symbol State₀ State₁ : Type*}
+variable (tm₀ : MultiTapeTM k₀ Symbol State₀) (tm₁ : MultiTapeTM k₁ Symbol State₁)
+variable {firstInput secondInput : List Symbol}
+
+/-- Extend a virtual-input configuration while retaining the first machine's tapes. -/
+def inputLift (firstCfg : Cfg k₀ Symbol State₀ firstInput)
+    (cfg : Cfg (k₁ + 1) Symbol (InputState State₁) firstInput) :=
+  ExtendTapes.embed (inputEmbedding k₀ k₁) cfg
+    (tapes firstCfg.workTapes (fun _ => none) (fun _ _ => none))
+    (tapes firstCfg.workTapePos 0 (fun _ => 0))
+
+/-- The second-phase embedding is tape extension followed by two sequential state embeddings. -/
+lemma embedSecond_eq (firstCfg : Cfg k₀ Symbol State₀ firstInput)
+    (cfg : Cfg k₁ Symbol State₁ secondInput) :
+    embedSecond tm₀ tm₁ firstCfg cfg =
+      Sequential.right (Sequential.right
+        (inputLift firstCfg (InputFromWorkTape.embed firstCfg.inputPos cfg))) := by
+  apply Cfg.ext
+  · cases hs : cfg.state <;>
+      simp [embedSecond, Sequential.right, Cfg.withState, inputLift, ExtendTapes.embed,
+        InputFromWorkTape.embed, hs]
+  · rfl
+  · exact (extend_input _ _ _ _ _).symm
+  · exact (extend_input _ _ _ _ _).symm
+  · rfl
+
+/-- The classifier embedding has the same tape extension. -/
+lemma classifyCfg_eq (firstCfg : Cfg k₀ Symbol State₀ firstInput)
+    (cfg : Cfg k₁ Symbol State₁ secondInput) (boundary : InputBoundary) :
+    classifyCfg tm₀ tm₁ firstCfg cfg boundary =
+      Sequential.right (Sequential.right
+        (inputLift firstCfg (InputFromWorkTape.classifyCfg firstCfg.inputPos cfg boundary))) := by
+  apply Cfg.ext
+  · cases hs : cfg.state <;>
+      simp [embedSecond, classifyCfg, Sequential.right, Cfg.withState, inputLift,
+        ExtendTapes.embed, InputFromWorkTape.embed, InputFromWorkTape.classifyCfg, hs]
+  · rfl
+  · exact (extend_input _ _ _ _ _).symm
+  · exact (extend_input _ _ _ _ _).symm
+  · rfl
+
+/-- Simulation of the second machine, at two composite steps per native step. -/
+lemma runFrom_secondPhase (firstCfg : Cfg k₀ Symbol State₀ firstInput)
+    (cfg : Cfg k₁ Symbol State₁ secondInput) (n : ℕ) :
+    (comp tm₀ tm₁).runFrom (embedSecond tm₀ tm₁ firstCfg cfg) (2 * n) =
+      embedSecond tm₀ tm₁ firstCfg (tm₁.runFrom cfg n) := by
+  rw [embedSecond_eq, comp, Sequential.runFrom_right, Sequential.runFrom_right]
+  simp only [inputMachine, inputLift, ExtendTapes.runFrom_embed, InputFromWorkTape.runFrom_embed]
+  exact (embedSecond_eq tm₀ tm₁ firstCfg _).symm
+
+/-- Odd composite steps are the intermediate classifier configurations of the input substitution. -/
+lemma runFrom_secondPhase_odd (firstCfg : Cfg k₀ Symbol State₀ firstInput)
+    (cfg : Cfg k₁ Symbol State₁ secondInput) (n : ℕ) :
+    ∃ boundary, (comp tm₀ tm₁).runFrom (embedSecond tm₀ tm₁ firstCfg cfg) (2 * n + 1) =
+      classifyCfg tm₀ tm₁ firstCfg (tm₁.runFrom cfg (n + 1)) boundary := by
+  obtain ⟨boundary, h⟩ := InputFromWorkTape.runFrom_odd tm₁ firstCfg.inputPos cfg n
+  refine ⟨boundary, ?_⟩
+  rw [embedSecond_eq, comp, Sequential.runFrom_right, Sequential.runFrom_right]
+  simp only [inputMachine, inputLift, ExtendTapes.runFrom_embed, h]
+  exact (classifyCfg_eq tm₀ tm₁ firstCfg _ boundary).symm
+
+/-- The initial classifier establishes the second machine's native initial configuration. -/
+lemma step_classify_init (firstCfg : Cfg k₀ Symbol State₀ firstInput) :
+    (comp tm₀ tm₁).step (classifyCfg tm₀ tm₁ firstCfg (tm₁.initCfg firstCfg.output) .right) =
+      embedSecond tm₀ tm₁ firstCfg (tm₁.initCfg firstCfg.output) := by
+  rw [classifyCfg_eq, comp, Sequential.step_right, Sequential.step_right]
+  simp only [inputMachine, inputLift, ExtendTapes.step_embed, InputFromWorkTape.step_init]
+  exact (embedSecond_eq tm₀ tm₁ firstCfg _).symm
+
+end Turing.MultiTapeTM.Composition

--- a/Cslib/Computability/Machines/Turing/MultiTape/Plumbing/README.md
+++ b/Cslib/Computability/Machines/Turing/MultiTape/Plumbing/README.md
@@ -11,3 +11,5 @@ These modules describe executable machines and their effects on configurations a
 - `InputFromWorkTape` simulates the native input on a work tape, preserving boundary clamping.
 - `Rewind` shares one controller between native-input and work-tape rewinding. Work-tape rewind
   starts immediately after contiguous contents and finishes at their first cell, including when empty.
+- `Composition` assembles output redirection, work-tape rewind, and input substitution with `seq`
+  and tape injections, then proves operational correctness.

--- a/CslibTests.lean
+++ b/CslibTests.lean
@@ -20,6 +20,7 @@ import CslibTests.Modal.Ideal
 import CslibTests.Modal.Stlc
 import CslibTests.MultiTapeAdapters
 import CslibTests.MultiTapeComplexity
+import CslibTests.MultiTapeComposition
 import CslibTests.MultiTapePlumbing
 import CslibTests.MultiTapeRewind
 import CslibTests.Reduction

--- a/CslibTests/MultiTapeComposition.lean
+++ b/CslibTests/MultiTapeComposition.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2026 Samuel Schlesinger. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Samuel Schlesinger
+-/
+
+import Cslib.Computability.Machines.Turing.MultiTape.Plumbing.Composition
+import Mathlib.Data.Fin.VecNotation
+import Mathlib.Tactic.FinCases
+
+/-! Regression tests for composition: empty output, boundary clamping, final-step output,
+and disjoint work tapes. -/
+
+namespace CslibTests.MultiTapeComposition
+
+open Turing.MultiTapeTM
+
+private def emit (symbol : Option Bool) : Turing.MultiTapeTM 0 Bool Unit where
+  q₀ := ()
+  tr _ _ _ := ⟨0, Fin.elim0, symbol, none⟩
+
+private def probe : Turing.MultiTapeTM 0 Bool (Fin 8) where
+  q₀ := 0
+  tr q input _ :=
+    ⟨(![-1, -1, 1, 1, 1, -1, -1, 1] : Fin 8 → SignType) q,
+      Fin.elim0, some input.isSome,
+      if h : q.val + 1 < 8 then some ⟨q.val + 1, h⟩ else none⟩
+
+-- Both outward moves clamp; the subsequent inward moves recover the only input symbol.
+example : ((comp (emit (some true)) probe).runFrom
+    ((comp (emit (some true)) probe).initCfg []) 21).output =
+      [true, false, false, true, false, false, true, false] := by rfl
+
+-- Empty intermediate output has adjacent blank boundaries and still reaches the second phase.
+example : ((comp (emit none) probe).runFrom
+    ((comp (emit none) probe).initCfg []) 20).output = List.replicate 8 false := by rfl
+
+-- Output emitted on the halting transition is retained, including when both machines have no tapes.
+example : ((comp (emit none) (emit (some true))).runFrom
+    ((comp (emit none) (emit (some true))).initCfg []) 6).output = [true] := by rfl
+
+example : ((comp (emit none) (emit (some true))).runFrom
+    ((comp (emit none) (emit (some true))).initCfg []) 6).state = none := by rfl
+
+private def writeEmit (symbol : Bool) : Turing.MultiTapeTM 1 Bool Bool where
+  q₀ := false
+  tr q _ work :=
+    if q then ⟨0, fun _ => (none, 0), work 0, none⟩
+    else ⟨0, fun _ => (some (some symbol), 0), none, some true⟩
+
+-- Each component reads its own write; the first component's output does not escape directly.
+example : ((comp (writeEmit true) (writeEmit false)).runFrom
+    ((comp (writeEmit true) (writeEmit false)).initCfg []) 10).output = [false] := by rfl
+
+example : ((comp (writeEmit true) (writeEmit false)).runFrom
+    ((comp (writeEmit true) (writeEmit false)).initCfg []) 10).workTapeSymbols =
+      ![some true, some true, some false] := by
+  funext i
+  fin_cases i <;> rfl
+
+end CslibTests.MultiTapeComposition


### PR DESCRIPTION
Construct machine composition from output redirection, work-tape rewind, and input substitution using the sequential combinator. Prove that the composite halts with the second machine's output on the first machine's result.

Part 5/6 of the TM composition stack. Depends on #873. Next: #875.

Validation: strict build, import checks, full tests, and linters.

This PR was composed with Astra via Codex.
