### PR TITLE
refactor(Foundations/Relation): reorganise relation modules

### DIFF
--- a/Cslib.lean
+++ b/Cslib.lean
@@ -91,12 +91,14 @@ public import Cslib.Foundations.Logic.InferenceSystem
 public import Cslib.Foundations.Logic.LogicalEquivalence
 public import Cslib.Foundations.Logic.Operators
 public import Cslib.Foundations.Relation.Attr
+public import Cslib.Foundations.Relation.Basic
 public import Cslib.Foundations.Relation.Confluence
 public import Cslib.Foundations.Relation.Defs
 public import Cslib.Foundations.Relation.Domain
 public import Cslib.Foundations.Relation.Euclidean
 public import Cslib.Foundations.Relation.Preserves
 public import Cslib.Foundations.Relation.Restriction
+public import Cslib.Foundations.Relation.Termination
 public import Cslib.Foundations.Semantics.FLTS.Basic
 public import Cslib.Foundations.Semantics.FLTS.FLTSToLTS
 public import Cslib.Foundations.Semantics.FLTS.LTSToFLTS

--- a/Cslib/Computability/Machines/Turing/SingleTape/NonDeterministic.lean
+++ b/Cslib/Computability/Machines/Turing/SingleTape/NonDeterministic.lean
@@ -6,12 +6,10 @@ Authors: Fabrizio Montesi
 
 module
 
-public import Cslib.Foundations.Relation.Defs
-public import Cslib.Foundations.Data.RelatesInSteps
 public import Cslib.Computability.Automata.NA.Basic
 public import Cslib.Computability.Automata.Transducers.Transducer
-public import Cslib.Foundations.Data.BiTape
 public import Cslib.Computability.Machines.Turing.SingleTape.Defs
+public import Cslib.Foundations.Data.RelatesInSteps
 
 /-! # Single-Tape Nondeterministic Turing Machines (NTMs)
 

--- a/Cslib/Foundations/Relation/Basic.lean
+++ b/Cslib/Foundations/Relation/Basic.lean
@@ -1,0 +1,79 @@
+/-
+Copyright (c) 2025 Thomas Waring. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Fabrizio Montesi, Thomas Waring, Chris Henson
+-/
+
+module
+
+public import Cslib.Foundations.Relation.Defs
+public import Mathlib.Order.WellFounded
+
+/-! # Basic properties of relations -/
+
+@[expose] public section
+
+variable {α : Type*} {r r₁ r₂ : α → α → Prop}
+
+theorem WellFounded.ofTransGen (trans_wf : WellFounded (Relation.TransGen r)) : WellFounded r := by
+  grind [WellFounded.wellFounded_iff_has_min, Relation.TransGen]
+
+@[simp, grind =]
+theorem WellFounded.iff_transGen : WellFounded (Relation.TransGen r) ↔ WellFounded r :=
+  ⟨ofTransGen, transGen⟩
+
+namespace Relation
+
+/-- A pair of subrelations lifts to transitivity on the relation. -/
+@[implicit_reducible]
+def transLeftRight (s s' r : α → α → Prop) [IsTrans α r] (h : s ≤ r) (h' : s' ≤ r) :
+    Trans s s' r where
+  trans hab hbc := _root_.trans (h _ _ hab) (h' _ _ hbc)
+
+/-- A subrelation lifts to transitivity on the left of the relation. -/
+@[implicit_reducible]
+def transLeft (s r : α → α → Prop) [IsTrans α r] (h : s ≤ r) : Trans s r r where
+  trans hab hbc := _root_.trans (h _ _ hab) hbc
+
+/-- A subrelation lifts to transitivity on the right of the relation. -/
+@[implicit_reducible]
+def transRight (s r : α → α → Prop) [IsTrans α r] (h : s ≤ r) : Trans r s r where
+  trans hab hbc := _root_.trans hab (h _ _ hbc)
+
+attribute [scoped grind] ReflGen TransGen ReflTransGen EqvGen
+
+theorem ReflGen.to_eqvGen (h : ReflGen r a b) : EqvGen r a b :=
+  EqvGen.reflGen_le_eqvGen r _ _ h
+
+theorem TransGen.to_eqvGen (h : TransGen r a b) : EqvGen r a b :=
+  EqvGen.transGen_le_eqvGen r _ _ h
+
+theorem ReflTransGen.to_eqvGen (h : ReflTransGen r a b) : EqvGen r a b :=
+  EqvGen.reflTransGen_le_eqvGen r _ _ h
+
+theorem SymmGen.to_eqvGen (h : SymmGen r a b) : EqvGen r a b :=
+  EqvGen.symmGen_le_eqvGen r _ _ h
+
+attribute [scoped grind →] ReflGen.to_eqvGen TransGen.to_eqvGen ReflTransGen.to_eqvGen
+  SymmGen.to_eqvGen
+
+@[deprecated _root_.refl (since := "2026-09-07")]
+theorem MJoin.refl (a : α) : MJoin r a a := _root_.refl a
+
+theorem MJoin.single (h : ReflTransGen r a b) : MJoin r a b := by
+  use b
+
+/-- If a relation is squeezed by a relation and its multi-step closure, they are multi-step equal -/
+theorem reflTransGen_mono_closed (h₁ : r₁ ≤ r₂) (h₂ : r₂ ≤ ReflTransGen r₁) :
+    ReflTransGen r₁ = ReflTransGen r₂ := by
+  ext a b
+  exact ⟨ReflTransGen.mono h₁ a b, reflTransGen_closed h₂ a b⟩
+
+@[deprecated Relation.ReflGen.stdSymm (since := "2026-09-03")]
+lemma ReflGen.symmGen_symm : ReflGen (SymmGen r) a b → ReflGen (SymmGen r) b a :=
+  Std.Symm.symm a b
+
+@[simp, grind =]
+theorem reflTransGen_symmGen : ReflTransGen (SymmGen r) = EqvGen r := EqvGen.reflTransGen_symmGen r
+
+end Relation

--- a/Cslib/Foundations/Relation/Confluence.lean
+++ b/Cslib/Foundations/Relation/Confluence.lean
@@ -6,18 +6,16 @@ Authors: Fabrizio Montesi, Thomas Waring, Chris Henson
 
 module
 
-public import Cslib.Foundations.Relation.Defs
+public import Cslib.Foundations.Relation.Termination
 public import Mathlib.Data.List.Pairwise
-public import Mathlib.Order.Comparable
-public import Mathlib.Order.WellFounded
 
 /-! # Relations: Confluence and Termination
 
-This module proves some properties regarding confluence and termination that are used for both
-lambda calculi and combinatory logic. Some notable theorems:
+This module proves some properties regarding confluence that are used for both lambda calculi and
+combinatory logic. Some notable theorems:
 
-* `Diamond.toConfluent`: the diamond property implies confluence
-* `LocallyConfluent.Terminating_toConfluent`: Newman's lemma
+* `Diamond.to_confluent`: the diamond property implies confluence
+* `LocallyConfluent.terminating_toConfluent`: Newman's lemma
 
 ## References
 
@@ -29,37 +27,7 @@ lambda calculi and combinatory logic. Some notable theorems:
 
 variable {α : Type*} {r r₁ r₂ : α → α → Prop}
 
-theorem WellFounded.ofTransGen (trans_wf : WellFounded (Relation.TransGen r)) : WellFounded r := by
-  grind [WellFounded.wellFounded_iff_has_min, Relation.TransGen]
-
-@[simp, grind =]
-theorem WellFounded.iff_transGen : WellFounded (Relation.TransGen r) ↔ WellFounded r :=
-  ⟨ofTransGen, transGen⟩
-
 namespace Relation
-
-attribute [scoped grind] ReflGen TransGen ReflTransGen EqvGen
-
-theorem ReflGen.to_eqvGen (h : ReflGen r a b) : EqvGen r a b :=
-  EqvGen.reflGen_le_eqvGen r _ _ h
-
-theorem TransGen.to_eqvGen (h : TransGen r a b) : EqvGen r a b :=
-  EqvGen.transGen_le_eqvGen r _ _ h
-
-theorem ReflTransGen.to_eqvGen (h : ReflTransGen r a b) : EqvGen r a b :=
-  EqvGen.reflTransGen_le_eqvGen r _ _ h
-
-theorem SymmGen.to_eqvGen (h : SymmGen r a b) : EqvGen r a b :=
-  EqvGen.symmGen_le_eqvGen r _ _ h
-
-attribute [scoped grind →] ReflGen.to_eqvGen TransGen.to_eqvGen ReflTransGen.to_eqvGen
-  SymmGen.to_eqvGen
-
-theorem MJoin.refl (a : α) : MJoin r a a := by
-  use a
-
-theorem MJoin.single (h : ReflTransGen r a b) : MJoin r a b := by
-  use b
 
 /-- Extending a multistep reduction by a single step preserves multi-joinability. -/
 lemma Diamond.extend (h : Diamond r) :
@@ -139,16 +107,6 @@ theorem confluent_of_unique_end {x : α} (h : ∀ y : α, ReflTransGen r y x) : 
 
 @[deprecated (since := "2026-09-03")] alias Confluent_of_unique_end := confluent_of_unique_end
 
-theorem normal_iff (r : α → α → Prop) (x : α) : Normal r x ↔ ∀ y, ¬ r x y := by
-  rw [Normal, not_exists]
-
-@[deprecated (since := "2026-09-03")] alias Normal_iff := normal_iff
-
-/-- A multi-step from a normal form must be reflexive. -/
-@[grind =>]
-theorem Normal.reflTransGen_eq (h : Normal r x) (xy : ReflTransGen r x y) : x = y := by
-  induction xy <;> grind
-
 /-- For a Church-Rosser relation, elements in an equivalence class must be multi-step related. -/
 theorem ChurchRosser.normal_eqvGen_reflTransGen (cr : ChurchRosser r) (norm : Normal r x)
     (xy : EqvGen r y x) : ReflTransGen r y x := by
@@ -166,95 +124,6 @@ theorem Confluent.equivalence_join_reflTransGen (h : Confluent r) :
     Equivalence (Join (ReflTransGen r)) := by
   apply equivalence_join
   grind
-
-lemma SN_iff_SN_of_rel (x : α) : SN r x ↔ ∀ y, r x y → SN r y := by grind [Acc]
-
-lemma SN.intro : (h : ∀ y, r x y → SN r y) → SN r x := (SN_iff_SN_of_rel x).mpr
-
-lemma SN.of_rel (hx : SN r x) (h : r x y) : SN r y := Acc.inv hx h
-
-@[grind →]
-lemma SN.of_rel_reflTransGen (hx : SN r x) (h : ReflTransGen r x y) : SN r y := by
-  induction h with
-  | refl => exact hx
-  | tail _ h ih => exact ih.of_rel h
-
-lemma SN.transGen (hx : SN r x) : SN (TransGen r) x := by
-  have eq : TransGen (Function.swap r) = (fun a b => TransGen r b a) := by
-    ext
-    exact transGen_swap
-  simpa [eq] using Acc.transGen hx
-
-lemma SN.of_le {r' : α → α → Prop} (hx : SN r x) (h : r' ≤ r) : SN r' x := by
-  refine Subrelation.accessible ?_ hx
-  exact subrelation_iff_le.mpr fun {x y} => h y x
-
-@[simp]
-lemma SN.iff_transGen (x : α) : SN (TransGen r) x ↔ SN r x :=
-  ⟨fun hx => hx.of_le <| fun _ _ => TransGen.single, transGen⟩
-
-/-- `SN r x` is equivalent to the more elementary definition, that there is no infinite sequence
-of reductions starting with `x`. -/
-theorem SN.iff_isEmpty_chain :
-    SN r x ↔ IsEmpty {f : ℕ → α | f 0 = x ∧ ∀ n, r (f n) (f (n + 1))} :=
-  acc_iff_isEmpty_descending_chain
-
-lemma SN.onFun_of_image {r : β → β → Prop} {f : α → β} (hx : SN r (f x)) :
-    SN (Function.onFun r f) x := InvImage.accessible f hx
-
-lemma SN.of_normal (hx : Normal r x) : SN r x := SN.intro fun y hy => (hx ⟨y, hy⟩).elim
-
-theorem SN.normalizable (hx : SN r x) : Normalizable r x := by
-  induction hx with | intro x h ih =>
-  by_cases hy: (∃ y, r x y)
-  · obtain ⟨y, hy⟩ := hy
-    obtain ⟨z, hz, hnormal⟩ := ih y hy
-    exact ⟨z, .head hy hz, hnormal⟩
-  · exists x
-
-lemma Terminating.apply (hr : Terminating r) (x : α) : SN r x := WellFounded.apply hr x
-
-lemma Terminating.iff_forall_sn : Terminating r ↔ ∀ x, SN r x :=
-  ⟨WellFounded.apply, WellFounded.intro⟩
-
-theorem Terminating.to_transGen (ht : Terminating r) : Terminating (TransGen r) := by
-  simp_rw [iff_forall_sn, SN.iff_transGen] at ht ⊢
-  exact ht
-
-@[deprecated (since := "2026-09-03")] alias Terminating.toTransGen := Terminating.to_transGen
-
-/-- A terminating relation is acyclic. -/
-theorem Terminating.to_acyclic (ht : Terminating r) : Acyclic r :=
-  ⟨fun x hx => ht.to_transGen.irrefl.irrefl x hx⟩
-
-@[deprecated (since := "2026-09-03")] alias Terminating.toAcyclic := Terminating.to_acyclic
-
-theorem Terminating.of_transGen : Terminating (TransGen r) → Terminating r := by
-  simp_rw [iff_forall_sn, SN.iff_transGen]
-  exact id
-
-@[deprecated (since := "2026-09-03")] alias Terminating.ofTransGen := Terminating.of_transGen
-
-theorem Terminating.iff_transGen : Terminating (TransGen r) ↔ Terminating r := by
-  simp_rw [iff_forall_sn, SN.iff_transGen]
-
-theorem Terminating.iff_isEmpty_chain :
-    Terminating r ↔ IsEmpty {f : ℕ → α // ∀ n, r (f n) (f (n + 1))} :=
-  wellFounded_iff_isEmpty_descending_chain
-
-theorem Terminating.of_le {r' : α → α → Prop} (hr : Terminating r) (h : r' ≤ r) :
-    Terminating r' := by
-  rw [iff_forall_sn] at hr ⊢
-  exact fun x => (hr x).of_le h
-
-lemma Terminating.subtype_sn (r : α → α → Prop) :
-    Terminating (α := {x // SN r x}) (fun a b => r a b) :=
-  iff_forall_sn.mpr fun x => x.property.onFun_of_image
-
-theorem Terminating.to_normalizing (hr : Terminating r) : Normalizing r :=
-  fun x => (hr.apply x).normalizable
-
-@[deprecated (since := "2026-09-03")] alias Terminating.isNormalizing := Terminating.to_normalizing
 
 theorem Terminating.confluent_iff_forall_unique_normal (ht : Terminating r) :
     Confluent r ↔ ∀ a : α, ∃! n : α, ReflTransGen r a n ∧ Normal r n := by
@@ -410,19 +279,6 @@ theorem Commute.join_confluent (c₁ : Confluent r₁) (c₂ : Confluent r₂) (
     Confluent (r₁ ⊔ r₂) := by
   rw [← Commute.to_confluent]
   apply_rules [join_left, symm]
-
-/-- If a relation is squeezed by a relation and its multi-step closure, they are multi-step equal -/
-theorem reflTransGen_mono_closed (h₁ : r₁ ≤ r₂) (h₂ : r₂ ≤ ReflTransGen r₁) :
-    ReflTransGen r₁ = ReflTransGen r₂ := by
-  ext a b
-  exact ⟨ReflTransGen.mono h₁ a b, reflTransGen_closed h₂ a b⟩
-
-@[deprecated Relation.ReflGen.stdSymm (since := "2026-09-03")]
-lemma ReflGen.symmGen_symm : ReflGen (SymmGen r) a b → ReflGen (SymmGen r) b a :=
-  Std.Symm.symm a b
-
-@[simp, grind =]
-theorem reflTransGen_symmGen : ReflTransGen (SymmGen r) = EqvGen r := EqvGen.reflTransGen_symmGen r
 
 /-- `Relator.RightUnique` corresponds to deterministic reductions, which are confluent, as all
 multi-reductions with a common origin start the same (this fact is

--- a/Cslib/Foundations/Relation/Defs.lean
+++ b/Cslib/Foundations/Relation/Defs.lean
@@ -9,7 +9,6 @@ module
 public import Cslib.Init
 public import Mathlib.Data.Set.CoeSort
 public import Mathlib.Logic.Relation
-public import Mathlib.Order.Basic
 
 /-! # Relations: Definitions
 
@@ -24,9 +23,7 @@ public import Mathlib.Order.Basic
 
 namespace Relation
 
-@[nolint defsWithUnderscore]
-instance (r : α → α → Prop) (s : Set α) : CoeDep (α → α → Prop) r (s → s → Prop) where
-  coe a b := r a b
+/-! ### Operations on relations -/
 
 /-- The empty (heterogeneous) relation, which always returns `False`. -/
 @[nolint unusedArguments]
@@ -45,19 +42,20 @@ abbrev MJoin (r : α → α → Prop) := Join (ReflTransGen r)
 /-- The relation `r` 'up to' the relation `s`. -/
 def UpTo (r s : α → α → Prop) : α → α → Prop := Comp s (Comp r s)
 
-/-- A relation `r` is (right) Euclidean if `r a b` and `r a c` guarantee `r b c`. -/
-class RightEuclidean (r : α → α → Prop) where
-  rightEuclidean : r a b → r a c → r b c
-
-/-- A relation `r` is (left) Euclidean if `r a c` and `r b c` guarantee `r a b`. -/
-class LeftEuclidean (r : α → α → Prop) where
-  leftEuclidean {a b c} : r a c → r b c → r a b
+/-! ### Confluence and commutation properties -/
 
 /-- A relation has the diamond property when all reductions with a common origin are joinable -/
 abbrev Diamond (r : α → α → Prop) := ∀ {a b c : α}, r a b → r a c → Join r b c
 
+/-- Generalization of `Diamond` to two relations. -/
+def DiamondCommute (r₁ r₂ : α → α → Prop) :=
+  ∀ {x y₁ y₂}, r₁ x y₁ → r₂ x y₂ → ∃ z, r₂ y₁ z ∧ r₁ y₂ z
+
 /-- A relation is confluent when its reflexive transitive closure has the diamond property. -/
 abbrev Confluent (r : α → α → Prop) := Diamond (ReflTransGen r)
+
+/-- Generalization of `Confluent` to two relations. -/
+abbrev Commute (r₁ r₂ : α → α → Prop) := DiamondCommute (ReflTransGen r₁) (ReflTransGen r₂)
 
 /-- A relation is semi-confluent when single and multiple steps with common origin
   are multi-joinable. -/
@@ -67,15 +65,22 @@ abbrev SemiConfluent (r : α → α → Prop) :=
 /-- A relation has the Church Rosser property when equivalence implies multi-joinability. -/
 abbrev ChurchRosser (r : α → α → Prop) := ∀ {x y}, EqvGen r x y → Join (ReflTransGen r) x y
 
-/-- Relation `r` preserves predicate `P`. -/
-def Preserves (r : α → α → Prop) (P : α → Prop) : Prop := ∀ ⦃a b⦄, r a b → P a → P b
+/-- A relation is locally confluent when all reductions with a common origin are multi-joinable -/
+abbrev LocallyConfluent (r : α → α → Prop) :=
+  ∀ {a b c : α}, r a b → r a c → Join (ReflTransGen r) b c
+
+/-- A relation is strongly confluent when single steps are reflexive- and multi-joinable. -/
+abbrev StronglyConfluent (r : α → α → Prop) :=
+  ∀ {x y₁ y₂}, r x y₁ → r x y₂ → ∃ z, ReflGen r y₁ z ∧ ReflTransGen r y₂ z
+
+/-- Generalization of `StronglyConfluent` to two relations. -/
+def StronglyCommute (r₁ r₂ : α → α → Prop) :=
+  ∀ {x y₁ y₂}, r₁ x y₁ → r₂ x y₂ → ∃ z, ReflGen r₂ y₁ z ∧ ReflTransGen r₁ y₂ z
+
+/-! ### Normalization properties -/
 
 /-- An element is reducible with respect to a relation if there is a value it is related to. -/
 abbrev Reducible (r : α → α → Prop) (x : α) : Prop := ∃ y, r x y
-
-/-- A relation `r` is serial if every element is `Reducible`, i.e. `Relator.LeftTotal`. -/
-class Serial (r : α → α → Prop) where
-  serial : Relator.LeftTotal r
 
 /-- An element is normal if it is not reducible. -/
 abbrev Normal (r : α → α → Prop) (x : α) : Prop := ¬ Reducible r x
@@ -92,57 +97,45 @@ abbrev Normalizing (r : α → α → Prop) : Prop :=
 the inverse of `r`. -/
 abbrev SN (r : α → α → Prop) := Acc (fun a b => r b a)
 
-/-- A relation is acyclic if its transitive closure is irreflexive, equivalently if it admits no
-nonempty cycle. -/
-abbrev Acyclic (r : α → α → Prop) := Std.Irrefl (TransGen r)
-
 /-- A relation is terminating when the inverse of its transitive closure is well-founded.
   Note that this is also called Noetherian or strongly normalizing in the literature. -/
 abbrev Terminating (r : α → α → Prop) := WellFounded (fun a b => r b a)
 
+/-- A relation is acyclic if its transitive closure is irreflexive, equivalently if it admits no
+nonempty cycle. -/
+abbrev Acyclic (r : α → α → Prop) := Std.Irrefl (TransGen r)
+
 /-- A relation is convergent when it is both confluent and terminating. -/
 abbrev Convergent (r : α → α → Prop) := Confluent r ∧ Terminating r
 
-/-- A relation is locally confluent when all reductions with a common origin are multi-joinable -/
-abbrev LocallyConfluent (r : α → α → Prop) :=
-  ∀ {a b c : α}, r a b → r a c → Join (ReflTransGen r) b c
+/-! ### Modal properties -/
 
-/-- A relation is strongly confluent when single steps are reflexive- and multi-joinable. -/
-abbrev StronglyConfluent (r : α → α → Prop) :=
-  ∀ {x y₁ y₂}, r x y₁ → r x y₂ → ∃ z, ReflGen r y₁ z ∧ ReflTransGen r y₂ z
+/-- A relation `r` is (right) Euclidean if `r a b` and `r a c` guarantee `r b c`. -/
+class RightEuclidean (r : α → α → Prop) where
+  rightEuclidean : r a b → r a c → r b c
 
-/-- Generalization of `StronglyConfluent` to two relations. -/
-def StronglyCommute (r₁ r₂ : α → α → Prop) :=
-  ∀ {x y₁ y₂}, r₁ x y₁ → r₂ x y₂ → ∃ z, ReflGen r₂ y₁ z ∧ ReflTransGen r₁ y₂ z
+/-- A relation `r` is (left) Euclidean if `r a c` and `r b c` guarantee `r a b`. -/
+class LeftEuclidean (r : α → α → Prop) where
+  leftEuclidean {a b c} : r a c → r b c → r a b
 
-/-- Generalization of `Diamond` to two relations. -/
-def DiamondCommute (r₁ r₂ : α → α → Prop) :=
-  ∀ {x y₁ y₂}, r₁ x y₁ → r₂ x y₂ → ∃ z, r₂ y₁ z ∧ r₁ y₂ z
+/-- A relation `r` is serial if every element is `Reducible`, i.e. `Relator.LeftTotal`. -/
+class Serial (r : α → α → Prop) where
+  serial : Relator.LeftTotal r
 
-/-- Generalization of `Confluent` to two relations. -/
-abbrev Commute (r₁ r₂ : α → α → Prop) := DiamondCommute (ReflTransGen r₁) (ReflTransGen r₂)
-
-/-- A pair of subrelations lifts to transitivity on the relation. -/
-@[implicit_reducible]
-def transLeftRight (s s' r : α → α → Prop) [IsTrans α r] (h : s ≤ r) (h' : s' ≤ r) :
-    Trans s s' r where
-  trans hab hbc := _root_.trans (h _ _ hab) (h' _ _ hbc)
-
-/-- A subrelation lifts to transitivity on the left of the relation. -/
-@[implicit_reducible]
-def transLeft (s r : α → α → Prop) [IsTrans α r] (h : s ≤ r) : Trans s r r where
-  trans hab hbc := _root_.trans (h _ _ hab) hbc
-
-/-- A subrelation lifts to transitivity on the right of the relation. -/
-@[implicit_reducible]
-def transRight (s r : α → α → Prop) [IsTrans α r] (h : s ≤ r) : Trans r s r where
-  trans hab hbc := _root_.trans hab (h _ _ hbc)
+/-- Relation `r` preserves predicate `P`. -/
+def Preserves (r : α → α → Prop) (P : α → Prop) : Prop := ∀ ⦃a b⦄, r a b → P a → P b
 
 end Relation
+
+/-! ### Properties of relations on restrictions of their (co)domain -/
 
 namespace Set
 
 open Relation
+
+@[nolint defsWithUnderscore]
+instance (r : α → α → Prop) (s : Set α) : CoeDep (α → α → Prop) r (s → s → Prop) where
+  coe a b := r a b
 
 /-- `ReflOn s r` is true when a relation `r` is reflexive on its restriction to a set `s`. -/
 def ReflOn (s : Set α) (r : α → α → Prop) : Prop :=

--- a/Cslib/Foundations/Relation/Defs.lean
+++ b/Cslib/Foundations/Relation/Defs.lean
@@ -42,6 +42,9 @@ abbrev MJoin (r : α → α → Prop) := Join (ReflTransGen r)
 /-- The relation `r` 'up to' the relation `s`. -/
 def UpTo (r s : α → α → Prop) : α → α → Prop := Comp s (Comp r s)
 
+/-- Relation `r` preserves predicate `P`. -/
+def Preserves (r : α → α → Prop) (P : α → Prop) : Prop := ∀ ⦃a b⦄, r a b → P a → P b
+
 /-! ### Confluence and commutation properties -/
 
 /-- A relation has the diamond property when all reductions with a common origin are joinable -/
@@ -121,9 +124,6 @@ class LeftEuclidean (r : α → α → Prop) where
 /-- A relation `r` is serial if every element is `Reducible`, i.e. `Relator.LeftTotal`. -/
 class Serial (r : α → α → Prop) where
   serial : Relator.LeftTotal r
-
-/-- Relation `r` preserves predicate `P`. -/
-def Preserves (r : α → α → Prop) (P : α → Prop) : Prop := ∀ ⦃a b⦄, r a b → P a → P b
 
 end Relation
 

--- a/Cslib/Foundations/Relation/Domain.lean
+++ b/Cslib/Foundations/Relation/Domain.lean
@@ -6,8 +6,8 @@ Authors: Fabrizio Montesi, Thomas Waring, Chris Henson
 
 module
 
-public import Cslib.Foundations.Relation.Defs
 public import Mathlib.Data.Set.Basic
+public import Cslib.Foundations.Relation.Defs
 
 /-! # Relations: Domain and Codomain
 

--- a/Cslib/Foundations/Relation/Preserves.lean
+++ b/Cslib/Foundations/Relation/Preserves.lean
@@ -6,7 +6,7 @@ Authors: Fabrizio Montesi
 
 module
 
-public import Cslib.Foundations.Relation.Defs
+public import Cslib.Foundations.Relation.Basic
 public import Mathlib.Logic.Function.Defs
 
 /-! # Relations: preservation of properties -/

--- a/Cslib/Foundations/Relation/Restriction.lean
+++ b/Cslib/Foundations/Relation/Restriction.lean
@@ -6,7 +6,6 @@ Authors: Chris Henson
 
 module
 
-public import Cslib.Foundations.Relation.Defs
 public import Cslib.Foundations.Relation.Domain
 
 /-! # Relations: Properties on set restrictions

--- a/Cslib/Foundations/Relation/Termination.lean
+++ b/Cslib/Foundations/Relation/Termination.lean
@@ -1,0 +1,118 @@
+/-
+Copyright (c) 2025 Fabrizio Montesi and Thomas Waring. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Fabrizio Montesi, Thomas Waring, Chris Henson
+-/
+
+module
+
+public import Cslib.Foundations.Relation.Basic
+
+/-! # Termination (well-foundedness) properties of relations -/
+
+@[expose] public section
+
+variable {α : Type*} {r r₁ r₂ : α → α → Prop}
+
+namespace Relation
+
+theorem normal_iff (r : α → α → Prop) (x : α) : Normal r x ↔ ∀ y, ¬ r x y := by
+  rw [Normal, not_exists]
+
+@[deprecated (since := "2026-09-03")] alias Normal_iff := normal_iff
+
+/-- A multi-step from a normal form must be reflexive. -/
+@[grind =>]
+theorem Normal.reflTransGen_eq (h : Normal r x) (xy : ReflTransGen r x y) : x = y := by
+  induction xy <;> grind
+
+lemma SN_iff_SN_of_rel (x : α) : SN r x ↔ ∀ y, r x y → SN r y := by grind [Acc]
+
+lemma SN.intro : (h : ∀ y, r x y → SN r y) → SN r x := (SN_iff_SN_of_rel x).mpr
+
+lemma SN.of_rel (hx : SN r x) (h : r x y) : SN r y := Acc.inv hx h
+
+@[grind →]
+lemma SN.of_rel_reflTransGen (hx : SN r x) (h : ReflTransGen r x y) : SN r y := by
+  induction h with
+  | refl => exact hx
+  | tail _ h ih => exact ih.of_rel h
+
+lemma SN.transGen (hx : SN r x) : SN (TransGen r) x := by
+  have eq : TransGen (Function.swap r) = (fun a b => TransGen r b a) := by
+    ext
+    exact transGen_swap
+  simpa [eq] using Acc.transGen hx
+
+lemma SN.of_le {r' : α → α → Prop} (hx : SN r x) (h : r' ≤ r) : SN r' x := by
+  refine Subrelation.accessible ?_ hx
+  exact subrelation_iff_le.mpr fun {x y} => h y x
+
+@[simp]
+lemma SN.iff_transGen (x : α) : SN (TransGen r) x ↔ SN r x :=
+  ⟨fun hx => hx.of_le <| fun _ _ => TransGen.single, transGen⟩
+
+/-- `SN r x` is equivalent to the more elementary definition, that there is no infinite sequence
+of reductions starting with `x`. -/
+theorem SN.iff_isEmpty_chain :
+    SN r x ↔ IsEmpty {f : ℕ → α | f 0 = x ∧ ∀ n, r (f n) (f (n + 1))} :=
+  acc_iff_isEmpty_descending_chain
+
+lemma SN.onFun_of_image {r : β → β → Prop} {f : α → β} (hx : SN r (f x)) :
+    SN (Function.onFun r f) x := InvImage.accessible f hx
+
+lemma SN.of_normal (hx : Normal r x) : SN r x := SN.intro fun y hy => (hx ⟨y, hy⟩).elim
+
+theorem SN.normalizable (hx : SN r x) : Normalizable r x := by
+  induction hx with | intro x h ih =>
+  by_cases hy: (∃ y, r x y)
+  · obtain ⟨y, hy⟩ := hy
+    obtain ⟨z, hz, hnormal⟩ := ih y hy
+    exact ⟨z, .head hy hz, hnormal⟩
+  · exists x
+
+lemma Terminating.apply (hr : Terminating r) (x : α) : SN r x := WellFounded.apply hr x
+
+lemma Terminating.iff_forall_sn : Terminating r ↔ ∀ x, SN r x :=
+  ⟨WellFounded.apply, WellFounded.intro⟩
+
+theorem Terminating.to_transGen (ht : Terminating r) : Terminating (TransGen r) := by
+  simp_rw [iff_forall_sn, SN.iff_transGen] at ht ⊢
+  exact ht
+
+@[deprecated (since := "2026-09-03")] alias Terminating.toTransGen := Terminating.to_transGen
+
+/-- A terminating relation is acyclic. -/
+theorem Terminating.to_acyclic (ht : Terminating r) : Acyclic r :=
+  ⟨fun x hx => ht.to_transGen.irrefl.irrefl x hx⟩
+
+@[deprecated (since := "2026-09-03")] alias Terminating.toAcyclic := Terminating.to_acyclic
+
+theorem Terminating.of_transGen : Terminating (TransGen r) → Terminating r := by
+  simp_rw [iff_forall_sn, SN.iff_transGen]
+  exact id
+
+@[deprecated (since := "2026-09-03")] alias Terminating.ofTransGen := Terminating.of_transGen
+
+theorem Terminating.iff_transGen : Terminating (TransGen r) ↔ Terminating r := by
+  simp_rw [iff_forall_sn, SN.iff_transGen]
+
+theorem Terminating.iff_isEmpty_chain :
+    Terminating r ↔ IsEmpty {f : ℕ → α // ∀ n, r (f n) (f (n + 1))} :=
+  wellFounded_iff_isEmpty_descending_chain
+
+theorem Terminating.of_le {r' : α → α → Prop} (hr : Terminating r) (h : r' ≤ r) :
+    Terminating r' := by
+  rw [iff_forall_sn] at hr ⊢
+  exact fun x => (hr x).of_le h
+
+lemma Terminating.subtype_sn (r : α → α → Prop) :
+    Terminating (α := {x // SN r x}) (fun a b => r a b) :=
+  iff_forall_sn.mpr fun x => x.property.onFun_of_image
+
+theorem Terminating.to_normalizing (hr : Terminating r) : Normalizing r :=
+  fun x => (hr.apply x).normalizable
+
+@[deprecated (since := "2026-09-03")] alias Terminating.isNormalizing := Terminating.to_normalizing
+
+end Relation

--- a/Cslib/Foundations/Semantics/LTS/Bisimulation.lean
+++ b/Cslib/Foundations/Semantics/LTS/Bisimulation.lean
@@ -7,7 +7,6 @@ Authors: Fabrizio Montesi, Thomas Waring
 module
 
 public import Cslib.Foundations.Relation.Domain
-public import Cslib.Foundations.Semantics.LTS.Simulation
 public import Cslib.Foundations.Semantics.LTS.TraceEq
 public import Mathlib.Tactic.TFAE
 

--- a/Cslib/Foundations/Semantics/LTS/ExampleTermination.lean
+++ b/Cslib/Foundations/Semantics/LTS/ExampleTermination.lean
@@ -7,7 +7,6 @@ Authors: Samuel Schlesinger
 module
 
 public import Cslib.Foundations.Semantics.LTS.Termination
-public import Mathlib.Order.WellFounded
 
 /-!
 # Examples separating boundedness, termination, and acyclicity

--- a/Cslib/Foundations/Semantics/LTS/Termination.lean
+++ b/Cslib/Foundations/Semantics/LTS/Termination.lean
@@ -6,10 +6,8 @@ Authors: Fabrizio Montesi
 
 module
 
-public import Cslib.Foundations.Relation.Confluence
+public import Cslib.Foundations.Relation.Termination
 public import Cslib.Foundations.Semantics.LTS.Execution
-public import Mathlib.Data.Fintype.Card
-public import Mathlib.Data.List.Chain
 public import Mathlib.SetTheory.Cardinal.Finite
 
 /-!

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Stlc/Safety.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Stlc/Safety.lean
@@ -6,10 +6,9 @@ Authors: Chris Henson
 
 module
 
+public import Cslib.Foundations.Relation.Defs
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Stlc.Basic
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.FullBeta
-public import Cslib.Foundations.Relation.Confluence
-public import Cslib.Foundations.Relation.Preserves
 
 /-! # λ-calculus
 

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Stlc/StrongNorm.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Stlc/StrongNorm.lean
@@ -6,12 +6,8 @@ Authors: David Wegmann
 
 module
 
-public import Cslib.Foundations.Data.HasFresh
-public import Cslib.Languages.LambdaCalculus.LocallyNameless.Stlc.Basic
-public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.FullBeta
-public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.StrongNorm
-public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.LcAt
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.MultiSubst
+public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.StrongNorm
 
 /-! Strong normalization (termination) for full beta-reduction of simply typed lambda calculus. -/
 

--- a/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/StrongNorm.lean
+++ b/Cslib/Languages/LambdaCalculus/LocallyNameless/Untyped/StrongNorm.lean
@@ -6,10 +6,8 @@ Authors: David Wegmann
 
 module
 
-public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.FullBeta
+public import Cslib.Foundations.Relation.Termination
 public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.MultiApp
-public import Cslib.Languages.LambdaCalculus.LocallyNameless.Untyped.LcAt
-public import Cslib.Foundations.Relation.Confluence
 
 /-! Strong normalization (termination) for full beta-reduction of untyped lambda calculus. -/
 


### PR DESCRIPTION
This PR:
- Adds two files under `Relation`: `Basic`, for simple properties, and `Termination`, for properties related to well-foundedness.
- Moves results unrelated to commutation or confluence from `Confluence` into `Basic` or `Termination`.
- Reorders `Relation.Defs` so that related properties are defined together, and adds headings.
- Minimises some imports.