### PR TITLE
ci(weekly-lints): pass the build status to the Zulip report

### DIFF
--- a/.github/workflows/weekly-lints.yml
+++ b/.github/workflows/weekly-lints.yml
@@ -52,13 +52,16 @@ jobs:
       continue-on-error: true
       run: |
         lean_outfile=$(mktemp)
-        (lake build || true) 2>&1 | tee "${lean_outfile}"
+        build_status=0
+        lake build 2>&1 | tee "${lean_outfile}" || build_status=$?
+        if [ "${build_status}" -eq 0 ]; then build_success=true; else build_success=false; fi
 
         # Process output for posting to Zulip
         SHA=${{ github.sha }} \
         REPO=${{ github.repository }} \
         RUN_ID=${{ github.run_id }} \
         INFO=true \
+        SUCCESS="${build_success}" \
           "${CI_SCRIPTS_DIR}/reporting/zulip_build_report.sh" "${lean_outfile}" > "${GITHUB_OUTPUT}"
 
     - name: Post output to Zulip

--- a/.github/workflows/weekly-lints.yml
+++ b/.github/workflows/weekly-lints.yml
@@ -51,6 +51,9 @@ jobs:
       working-directory: ${{ github.workspace }}/${{ env.CSLIB }}
       continue-on-error: true
       run: |
+        # The default step shell is `bash -e` without `pipefail`, so the status of
+        # `lake build | tee` would be tee's. Make the pipeline report lake's instead.
+        set -o pipefail
         lean_outfile=$(mktemp)
         build_status=0
         lake build 2>&1 | tee "${lean_outfile}" || build_status=$?


### PR DESCRIPTION
The report script marks a run with a green checkmark only when the caller sets `SUCCESS=true`. This workflow never did: the switch was added to the script in mathlib-ci in March 2026, and the nightly workflows there were updated to set it, but the weekly workflows in Mathlib and CSLib were not. The result is that every weekly report has been posted with a red X, even when the build was clean and had no linter messages.

The solution is to just capture the exit status of `lake build` and pass it through, as in [the corresponding Mathlib PR](https://github.com/leanprover-community/mathlib4/pull/43551).
