### PR TITLE
ci(nightly-testing): pass ZULIP_API_KEY through env instead of interpolating into script text

### DIFF
--- a/.github/workflows/report_failures_nightly-testing.yml
+++ b/.github/workflows/report_failures_nightly-testing.yml
@@ -268,6 +268,7 @@ jobs:
         BUMP_VERSION: ${{ steps.bump_version.outputs.result }}
         BUMP_BRANCH: ${{ steps.latest_bump_branch.outputs.result }}
         SHA: ${{ env.SHA }}
+        ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
       run: |
         echo "Installing zulip CLI..."
         pip install zulip
@@ -278,7 +279,7 @@ jobs:
         {
           echo "[api]"
           echo "email=github-mathlib4-bot@leanprover.zulipchat.com"
-          echo "key=${{ secrets.ZULIP_API_KEY }}"
+          echo "key=$ZULIP_API_KEY"
           echo "site=https://leanprover.zulipchat.com"
         } > ~/.zuliprc
         chmod 600 ~/.zuliprc


### PR DESCRIPTION
Move the key into the step's `env:` block and reference it as a shell variable, matching how the step already receives its other values.