### PR TITLE
ci: lint workflow files with actionlint

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,31 @@
+name: actionlint
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: Lint workflow files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: |
+            .github/workflows
+
+      # Also runs shellcheck over every `run:` block and pyflakes over
+      # `shell: python` steps.
+      - uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2.2.0
+        with:
+          version: 1.7.12

--- a/.github/workflows/bump_toolchain_nightly-testing.yml
+++ b/.github/workflows/bump_toolchain_nightly-testing.yml
@@ -45,7 +45,7 @@ jobs:
         GH_TOKEN: ${{ steps.app-token.outputs.token }}
       run: |
         # Extract date from RELEASE_TAG (format: nightly-YYYY-MM-DD)
-        DATE_PART=$(echo "$RELEASE_TAG" | sed 's/nightly-//')
+        DATE_PART="${RELEASE_TAG#nightly-}"
         NIGHTLY_TESTING_TAG="nightly-testing-${DATE_PART}"
         echo "NIGHTLY_TESTING_TAG=$NIGHTLY_TESTING_TAG" >> "${GITHUB_ENV}"
 

--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set TEST_ARGS manually
         run: |
-          echo "TEST_ARGS='--wfail --iofail'" >> $GITHUB_ENV
+          echo "TEST_ARGS='--wfail --iofail'" >> "$GITHUB_ENV"
         shell: bash
       - uses: leanprover/lean-action@v1
         with:


### PR DESCRIPTION
Adds a workflow that runs actionlint over the `.github/workflows` directory whenever those files change. actionlint checks expression types (used in the little GitHub Action DSL), undefined step/output references and needs/if conditions, and runs shellcheck over every `run:` shell block and [pyflakes](https://github.com/PyCQA/pyflakes) over `shell: python` chunks.

To make sure that adding this workflow does not immediately break the build, I did a manual one-off run and found one thing, which is fixed here: an `echo | sed` pipeline that is now a parameter expansion.
