### PR TITLE
chore(PFunctor): drop simp tags from non-universe generic bind lemma

### DIFF
--- a/Cslib/Foundations/Data/PFunctor/Free.lean
+++ b/Cslib/Foundations/Data/PFunctor/Free.lean
@@ -107,7 +107,7 @@ protected def bind : P.FreeM α → (α → P.FreeM β) → P.FreeM β
 
 instance : Bind (P.FreeM) where bind := .bind
 
-/-- Not marked `simp` since it is not universe level generic -/
+/-- Not marked `simp` since it is not universe level generic. -/
 theorem bind_eq_bind {α β : Type v} :
     (FreeM.bind : P.FreeM α → _ → P.FreeM β) = Bind.bind := rfl
 

--- a/Cslib/Foundations/Data/PFunctor/Free.lean
+++ b/Cslib/Foundations/Data/PFunctor/Free.lean
@@ -87,7 +87,6 @@ variable {P : PFunctor.{uA, uB}} {α β γ : Type*}
 
 instance : Pure (P.FreeM) where pure := .pure
 
-@[simp]
 theorem pure_eq_pure : (FreeM.pure : α → P.FreeM α) = pure := rfl
 
 /-- Lift a shape of the base polynomial functor into the free monad. -/
@@ -108,8 +107,7 @@ protected def bind : P.FreeM α → (α → P.FreeM β) → P.FreeM β
 
 instance : Bind (P.FreeM) where bind := .bind
 
-/-- Note that this lemma does not always apply, as it is universe-constrained by `Bind.bind`. -/
-@[simp]
+/-- Not marked `simp` since it is not universe level generic -/
 theorem bind_eq_bind {α β : Type v} :
     (FreeM.bind : P.FreeM α → _ → P.FreeM β) = Bind.bind := rfl
 


### PR DESCRIPTION
Currently `PFunctor.FreeM.bind mx my` is marked to `simp` to `mx >>= my`, but the notational `Bind.bind` only applies in cases where the return types of both monadic computation has the same universe level. This means other `simp` lemmas need to be written in both forms in order to provide full coverage.

This PR drops this tag, and a similar tag on `FreeM.pure`. It does not create a `simp` pathway in the other direction, but that could be worth considering I think.