### PR TITLE
ci: add Dependabot config for actions and pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  # Keep action pins fresh. Grouped so that all bumps land in a single weekly PR,
+  # which bounds the number of full Lean CI builds this triggers.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: ci
+
+  # Python packages installed by workflows (see requirements.txt in this directory).
+  # Major bumps are left for a human to review.
+  - package-ecosystem: pip
+    directory: /.github
+    schedule:
+      interval: weekly
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: ci


### PR DESCRIPTION
Add `.github/dependabot.yml` covering the two dependency sources CI actually has. Adding this will enable automatically created PRs if updates (checked weekly) are available, coming from two sources:

- GitHub Actions
- pip. Look only for minor and patch bumps. (Major versions are excluded, for now.)

Related to #894, which introduces the requirements file the pip entry watches. But mechanically, either one can merge first.
