### PR TITLE
ci: drop manual TEST_ARGS step

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -14,10 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set TEST_ARGS manually
-        run: |
-          echo "TEST_ARGS='--wfail --iofail'" >> $GITHUB_ENV
-        shell: bash
       - uses: leanprover/lean-action@v1
         with:
           build-args: "--wfail --iofail"


### PR DESCRIPTION
The step where we inject `TEST_ARGS` into the `GITHUB_ENV` environment variable was a workaround for a bug in `lean-action`, in which it ignored its own `test-args` input. That fix landed in leanprover/lean-action#153 and is included in `lean-action` since v1.6.0, which is what we pick up here on the CSLib side.

